### PR TITLE
feat: wire beach detail page to recent telemetry API

### DIFF
--- a/front/src/api/conditions.ts
+++ b/front/src/api/conditions.ts
@@ -1,0 +1,58 @@
+export interface BeachConditionDto {
+  id: string;
+  beachId: string;
+  observedAt: string;
+  waterTemperatureCelsius: number | null;
+  waveHeightMeters: number | null;
+  weatherSummary: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+const DEFAULT_API_BASE_URL = '';
+const BASIC_AUTH_USERNAME = import.meta.env.VITE_API_USERNAME ?? 'beach-admin';
+const BASIC_AUTH_PASSWORD = import.meta.env.VITE_API_PASSWORD ?? 'changeit';
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? DEFAULT_API_BASE_URL;
+
+function encodeBasicCredentials(username: string, password: string): string {
+  const credentials = `${username}:${password}`;
+  if (typeof globalThis.btoa === 'function') {
+    return globalThis.btoa(credentials);
+  }
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(credentials, 'utf-8').toString('base64');
+  }
+
+  throw new Error('Basic authentication requires a base64 encoder.');
+}
+
+function createBasicAuthHeader(): string {
+  return `Basic ${encodeBasicCredentials(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD)}`;
+}
+
+export async function fetchRecentConditions(beachId: string): Promise<BeachConditionDto[]> {
+  if (!beachId) {
+    return [];
+  }
+
+  const url = `${API_BASE_URL}/api/beaches/${beachId}/conditions/recent`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: createBasicAuthHeader(),
+      Accept: 'application/json',
+    },
+  });
+
+  if (response.status === 404) {
+    // Unknown beach identifier – treat as no available telemetry rather than surfacing an error.
+    return [];
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load conditions for beach ${beachId}: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as BeachConditionDto[];
+  return data.sort((a, b) => new Date(b.observedAt).getTime() - new Date(a.observedAt).getTime());
+}

--- a/front/src/components/BeachDetailView.tsx
+++ b/front/src/components/BeachDetailView.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect } from 'react';
-import { ThumbsUp, AlertTriangle, ZoomIn, ZoomOut, Heart } from 'lucide-react';
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { ThumbsUp, AlertTriangle, ZoomIn, ZoomOut, Heart, Loader2 } from 'lucide-react';
 import { Beach, beaches } from '../data/beaches';
 import { BottomNavigation } from './BottomNavigation';
 import { MonthlyHeatmap } from './MonthlyHeatmap';
@@ -11,6 +11,7 @@ import { Toaster } from './ui/sonner';
 import svgPaths from "../imports/svg-gmd8e6w0tp";
 import imgSubtract1 from "figma:asset/c5afd724d968366ab1d939ebd1fa1377e2d4b2bb.png";
 import { imgSubtract } from "../imports/svg-ogxba";
+import { fetchRecentConditions, type BeachConditionDto } from '../api/conditions';
 
 interface BeachDetailViewProps {
   beach: Beach;
@@ -47,15 +48,92 @@ function WaveLogo() {
 function CloudWeatherIcon() {
   return (
     <svg width="24" height="24" viewBox="0 0 50 50" fill="none">
-      <path 
-        d="M36.4125 20.8333H36.4583C38.9447 20.8333 41.3293 21.8211 43.0875 23.5792C44.8456 25.3374 45.8333 27.7219 45.8333 30.2083C45.8333 32.6947 44.8456 35.0793 43.0875 36.8375C41.3293 38.5956 38.9447 39.5833 36.4583 39.5833H14.5833C11.907 39.5839 9.3331 38.5542 7.39551 36.708C5.45792 34.8617 4.30529 32.3405 4.17668 29.6672C4.04807 26.994 4.95334 24.3738 6.70474 22.35C8.45614 20.3263 10.9193 19.0543 13.5833 18.7979M36.4125 20.8333C36.4417 20.4903 36.4569 20.1431 36.4583 19.7917C36.4629 16.8358 35.325 13.9925 33.2823 11.8559C31.2397 9.71934 28.4504 8.45479 25.4973 8.3265C22.5442 8.19821 19.6558 9.21611 17.4356 11.1675C15.2154 13.1189 13.8351 15.8528 13.5833 18.7979M36.4125 20.8333C36.2028 23.128 35.3061 25.3061 33.8396 27.0833M13.5833 18.7979C13.9125 18.766 14.2458 18.75 14.5833 18.75C16.9292 18.75 19.0937 19.525 20.8333 20.8333" 
-        stroke="#007DFC" 
-        strokeLinecap="round" 
-        strokeLinejoin="round" 
+      <path
+        d="M36.4125 20.8333H36.4583C38.9447 20.8333 41.3293 21.8211 43.0875 23.5792C44.8456 25.3374 45.8333 27.7219 45.8333 30.2083C45.8333 32.6947 44.8456 35.0793 43.0875 36.8375C41.3293 38.5956 38.9447 39.5833 36.4583 39.5833H14.5833C11.907 39.5839 9.3331 38.5542 7.39551 36.708C5.45792 34.8617 4.30529 32.3405 4.17668 29.6672C4.04807 26.994 4.95334 24.3738 6.70474 22.35C8.45614 20.3263 10.9193 19.0543 13.5833 18.7979M36.4125 20.8333C36.4417 20.4903 36.4569 20.1431 36.4583 19.7917C36.4629 16.8358 35.325 13.9925 33.2823 11.8559C31.2397 9.71934 28.4504 8.45479 25.4973 8.3265C22.5442 8.19821 19.6558 9.21611 17.4356 11.1675C15.2154 13.1189 13.8351 15.8528 13.5833 18.7979M36.4125 20.8333C36.2028 23.128 35.3061 25.3061 33.8396 27.0833M13.5833 18.7979C13.9125 18.766 14.2458 18.75 14.5833 18.75C16.9292 18.75 19.0937 19.525 20.8333 20.8333"
+        stroke="#007DFC"
+        strokeLinecap="round"
+        strokeLinejoin="round"
         strokeWidth="2"
       />
     </svg>
   );
+}
+
+type ConditionStatus = 'free' | 'normal' | 'busy';
+type ExtendedConditionStatus = ConditionStatus | 'unknown';
+
+interface HourlyTelemetryPoint {
+  hour: number;
+  status: ExtendedConditionStatus;
+  percentage: number;
+  waveHeight: number | null;
+  observedAt: string | null;
+}
+
+const STATUS_COLORS: Record<ExtendedConditionStatus, string> = {
+  busy: '#FF0000',
+  normal: '#FFEA00',
+  free: '#51FF00',
+  unknown: '#94A3B8',
+};
+
+const TELEMETRY_DEFAULT_MAX_WAVE_HEIGHT = 1.5;
+
+function classifyWaveHeight(waveHeight?: number | null): ConditionStatus {
+  if (waveHeight == null) {
+    return 'free';
+  }
+
+  if (waveHeight < 0.4) {
+    return 'free';
+  }
+
+  if (waveHeight < 1.0) {
+    return 'normal';
+  }
+
+  return 'busy';
+}
+
+function getStatusLabel(status: ExtendedConditionStatus) {
+  switch (status) {
+    case 'busy':
+      return '혼잡';
+    case 'normal':
+      return '보통';
+    case 'free':
+      return '여유';
+    default:
+      return '정보 없음';
+  }
+}
+
+function formatWaterTemperature(value: number | null | undefined) {
+  return value == null ? '데이터 없음' : `${value.toFixed(1)}°C`;
+}
+
+function formatWaveHeight(value: number | null | undefined) {
+  return value == null ? '데이터 없음' : `${value.toFixed(1)}m`;
+}
+
+function formatObservedAt(value: string | null | undefined) {
+  if (!value) {
+    return '관측 시간 정보 없음';
+  }
+
+  const date = new Date(value);
+  return date.toLocaleString('ko-KR', {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatHourRange(hour: number) {
+  const start = hour.toString().padStart(2, '0');
+  const end = ((hour + 1) % 24).toString().padStart(2, '0');
+  return `${start}:00~${end}:00`;
 }
 
 export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onDateChange, onNavigate, onBeachChange, favoriteBeaches = [], onFavoriteToggle }: BeachDetailViewProps) {
@@ -69,13 +147,191 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
   const startHeight = useRef(0);
   const sheetContentRef = useRef<HTMLDivElement>(null);
   const monthlyHeatmapRef = useRef<HTMLDivElement>(null);
+  const [conditions, setConditions] = useState<BeachConditionDto[]>([]);
+  const [isLoadingConditions, setIsLoadingConditions] = useState(false);
+  const [conditionsError, setConditionsError] = useState<string | null>(null);
+  const beachTelemetryId = beach.apiId ?? null;
 
-  const mockWeather = {
-    temp: weatherTemp,
-    condition: '맑음',
-    humidity: '65%',
-    wind: '3m/s',
-  };
+  useEffect(() => {
+    let ignore = false;
+
+    if (!beachTelemetryId) {
+      setConditions([]);
+      setConditionsError(null);
+      setIsLoadingConditions(false);
+      return;
+    }
+
+    setIsLoadingConditions(true);
+    setConditionsError(null);
+    setConditions([]);
+
+    fetchRecentConditions(beachTelemetryId)
+      .then((data) => {
+        if (ignore) return;
+        setConditions(data);
+      })
+      .catch((error) => {
+        if (ignore) return;
+        console.error('Failed to fetch beach conditions', error);
+        setConditions([]);
+        setConditionsError('관측 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.');
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsLoadingConditions(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [beachTelemetryId]);
+
+  const sortedConditions = useMemo(
+    () =>
+      [...conditions].sort(
+        (a, b) => new Date(b.observedAt).getTime() - new Date(a.observedAt).getTime(),
+      ),
+    [conditions],
+  );
+
+  const latestCondition = sortedConditions[0] ?? null;
+
+  const { hourlyData: hourlyConditions, bestHour, worstHour } = useMemo(() => {
+    if (sortedConditions.length === 0) {
+      return {
+        hourlyData: Array.from({ length: 24 }, (_, hour) => ({
+          hour,
+          status: 'unknown' as ExtendedConditionStatus,
+          percentage: 0,
+          waveHeight: null,
+          observedAt: null,
+        }) as HourlyTelemetryPoint),
+        bestHour: null,
+        worstHour: null,
+      };
+    }
+
+    const heights = sortedConditions
+      .map((condition) => condition.waveHeightMeters)
+      .filter((value): value is number => typeof value === 'number');
+
+    const referenceMax =
+      heights.length > 0
+        ? Math.max(TELEMETRY_DEFAULT_MAX_WAVE_HEIGHT, ...heights)
+        : TELEMETRY_DEFAULT_MAX_WAVE_HEIGHT;
+
+    const latestByHour = new Map<number, BeachConditionDto>();
+    sortedConditions.forEach((condition) => {
+      const hour = new Date(condition.observedAt).getHours();
+      const existing = latestByHour.get(hour);
+      if (!existing || new Date(condition.observedAt).getTime() > new Date(existing.observedAt).getTime()) {
+        latestByHour.set(hour, condition);
+      }
+    });
+
+    const hourlySeries: HourlyTelemetryPoint[] = Array.from({ length: 24 }, (_, hour) => {
+      const snapshot = latestByHour.get(hour);
+      if (!snapshot) {
+        return {
+          hour,
+          status: 'unknown',
+          percentage: 0,
+          waveHeight: null,
+          observedAt: null,
+        };
+      }
+
+      const waveHeight = snapshot.waveHeightMeters ?? null;
+
+      if (waveHeight == null) {
+        return {
+          hour,
+          status: 'unknown',
+          percentage: 0,
+          waveHeight: null,
+          observedAt: snapshot.observedAt,
+        };
+      }
+
+      const status = classifyWaveHeight(waveHeight);
+      const percentage = Math.min(Math.round((waveHeight / referenceMax) * 100), 100);
+
+      return {
+        hour,
+        status,
+        percentage,
+        waveHeight,
+        observedAt: snapshot.observedAt,
+      };
+    });
+
+    const availableHours = hourlySeries.filter((entry) => entry.waveHeight != null);
+    const calmest = availableHours.length
+      ? availableHours.reduce((prev, curr) => (curr.waveHeight! < prev.waveHeight! ? curr : prev))
+      : null;
+    const roughest = availableHours.length
+      ? availableHours.reduce((prev, curr) => (curr.waveHeight! > prev.waveHeight! ? curr : prev))
+      : null;
+
+    return {
+      hourlyData: hourlySeries,
+      bestHour: calmest,
+      worstHour: roughest,
+    };
+  }, [sortedConditions]);
+
+  const heatmapHourlyData = useMemo(
+    () =>
+      hourlyConditions.map(({ hour, status, percentage }) => ({
+        hour,
+        status: status === 'unknown' ? 'free' : status,
+        percentage,
+      })),
+    [hourlyConditions],
+  );
+
+  const derivedStatus: ExtendedConditionStatus = latestCondition
+    ? classifyWaveHeight(latestCondition.waveHeightMeters)
+    : 'unknown';
+
+  const displayStatus: ExtendedConditionStatus =
+    derivedStatus === 'unknown' ? beach.status : derivedStatus;
+
+  const statusTextColor =
+    displayStatus === 'busy'
+      ? '#FF0000'
+      : displayStatus === 'normal'
+      ? '#FFA500'
+      : displayStatus === 'free'
+      ? '#51FF00'
+      : '#6B7280';
+
+  const latestWaterTemperature = latestCondition?.waterTemperatureCelsius;
+  const temperatureDisplay = latestCondition
+    ? formatWaterTemperature(latestWaterTemperature)
+    : weatherTemp;
+  const waveHeightDisplay = formatWaveHeight(latestCondition?.waveHeightMeters ?? null);
+  const observedAtDisplay = latestCondition ? formatObservedAt(latestCondition.observedAt) : null;
+  const weatherSummary = latestCondition?.weatherSummary ?? '관측 데이터가 연결되는 중입니다.';
+  const isTelemetryConfigured = Boolean(beachTelemetryId);
+  const hasHourlyObservations = hourlyConditions.some((entry) => entry.waveHeight != null);
+  const bestHourRange = bestHour ? formatHourRange(bestHour.hour) : null;
+  const worstHourRange = worstHour ? formatHourRange(worstHour.hour) : null;
+  const bestHourStatus = bestHour ? getStatusLabel(bestHour.status) : null;
+  const worstHourStatus = worstHour ? getStatusLabel(worstHour.status) : null;
+  const bestHourWave = bestHour?.waveHeight ?? null;
+  const worstHourWave = worstHour?.waveHeight ?? null;
+  const recommendationFallback = isTelemetryConfigured
+    ? '관측 데이터가 부족해요'
+    : '센서 연결 후 이용 가능해요';
+  const observationLocation =
+    latestCondition &&
+    latestCondition.latitude != null &&
+    latestCondition.longitude != null
+      ? `${latestCondition.latitude.toFixed(3)}, ${latestCondition.longitude.toFixed(3)}`
+      : null;
 
   const formatDate = (date: Date | undefined) => {
     if (!date) return '날짜';
@@ -84,38 +340,8 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
     return `${month}/${day}`;
   };
 
-  // Mock data for hourly congestion (0-23 hours)
-  const hourlyData = Array.from({ length: 24 }, (_, i) => {
-    const hour = i;
-    let status: 'free' | 'normal' | 'busy';
-    let percentage = 0;
-    
-    // Simulate realistic beach congestion pattern
-    if (hour >= 12 && hour <= 16) {
-      status = 'busy';
-      percentage = 70 + Math.floor(Math.random() * 30); // 70-100%
-    } else if ((hour >= 10 && hour < 12) || (hour > 16 && hour <= 18)) {
-      status = 'normal';
-      percentage = 40 + Math.floor(Math.random() * 30); // 40-70%
-    } else {
-      status = 'free';
-      percentage = 10 + Math.floor(Math.random() * 30); // 10-40%
-    }
-    
-    return { hour, status, percentage };
-  });
-
   const currentHour = new Date().getHours();
-
-  const statusColors = {
-    busy: '#FF0000',
-    normal: '#FFEA00',
-    free: '#51FF00',
-  };
-
-  const getStatusLabel = (status: 'free' | 'normal' | 'busy') => {
-    return status === 'busy' ? '혼잡' : status === 'normal' ? '보통' : '여유';
-  };
+  const statusColors = STATUS_COLORS;
 
   const handleDragStart = (e: React.MouseEvent | React.TouchEvent) => {
     setIsDragging(true);
@@ -275,7 +501,7 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
                 />
               </svg>
               <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[10px] text-foreground whitespace-nowrap">
-                {weatherTemp}
+                {temperatureDisplay}
               </span>
             </button>
           </div>
@@ -313,11 +539,6 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
                   {/* All beach markers */}
                   {beaches.map((b) => {
                     const isSelected = b.id === beach.id;
-                    const statusColors = {
-                      busy: '#FF0000',
-                      normal: '#FFEA00',
-                      free: '#51FF00',
-                    };
                     
                     return (
                       <div 
@@ -389,7 +610,7 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
                                 <path 
                                   clipRule="evenodd" 
                                   d={svgPaths.p1a91f00} 
-                                  fill={statusColors[b.status]} 
+                                  fill={STATUS_COLORS[b.status]}
                                   fillRule="evenodd" 
                                   stroke="#ffffff" 
                                   strokeLinecap="round" 
@@ -488,9 +709,9 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
           <div className="mb-4 bg-card dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-border">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3 flex-1 min-w-0">
-                <div 
+                <div
                   className="w-3 h-3 rounded-full shrink-0"
-                  style={{ backgroundColor: statusColors[beach.status] }}
+                  style={{ backgroundColor: statusColors[displayStatus] }}
                 />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
@@ -513,24 +734,115 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
                   <p className="font-['Noto_Sans_KR:Regular',_sans-serif] text-[12px] text-muted-foreground">
                     {beach.address} · {beach.distance}
                   </p>
+                  {observedAtDisplay && (
+                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mt-1">
+                      최근 관측 {observedAtDisplay} · 파고 {waveHeightDisplay}
+                    </p>
+                  )}
+                </div>
+          </div>
+          <div className="text-right shrink-0 ml-2">
+            <p
+              className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[14px]"
+              style={{ color: statusTextColor }}
+            >
+              {getStatusLabel(displayStatus)}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Latest Telemetry Snapshot */}
+      <div className="mb-4">
+        <h3 className="font-['Noto_Sans_KR:Bold',_sans-serif] mb-3 text-foreground">실시간 관측</h3>
+        <div className="bg-card dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-border">
+          {isLoadingConditions ? (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px]">
+                관측 데이터를 불러오는 중이에요...
+              </span>
+            </div>
+          ) : latestCondition ? (
+            <div className="space-y-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mb-1">
+                    날씨 요약
+                  </p>
+                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-foreground text-[14px]">
+                    {weatherSummary}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mb-1">
+                    관측 시각
+                  </p>
+                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[13px] text-foreground">
+                    {observedAtDisplay}
+                  </p>
                 </div>
               </div>
-              <div className="text-right shrink-0 ml-2">
-                <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[14px]" 
-                   style={{ 
-                     color: beach.status === 'busy' ? '#FF0000' : beach.status === 'normal' ? '#FFA500' : '#51FF00'
-                   }}>
-                  {getStatusLabel(beach.status)}
+
+              <div className="grid grid-cols-3 gap-3">
+                <div className="bg-muted/60 dark:bg-gray-900/50 rounded-lg p-3 text-center">
+                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mb-1">
+                    수온
+                  </p>
+                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[15px] text-foreground">
+                    {formatWaterTemperature(latestWaterTemperature)}
+                  </p>
+                </div>
+                <div className="bg-muted/60 dark:bg-gray-900/50 rounded-lg p-3 text-center">
+                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mb-1">
+                    파고
+                  </p>
+                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[15px] text-foreground">
+                    {waveHeightDisplay}
+                  </p>
+                </div>
+                <div className="bg-muted/60 dark:bg-gray-900/50 rounded-lg p-3 text-center">
+                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mb-1">
+                    현재 상태
+                  </p>
+                  <p
+                    className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[15px]"
+                    style={{ color: statusTextColor }}
+                  >
+                    {getStatusLabel(displayStatus)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center gap-3 py-8 text-center text-muted-foreground">
+              <AlertTriangle className="w-6 h-6" />
+              <div>
+                <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[13px]">
+                  {isTelemetryConfigured
+                    ? '최근 24시간의 관측 데이터가 없어요.'
+                    : '이 해수욕장은 아직 관측 데이터가 연결되지 않았어요.'}
+                </p>
+                <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mt-1">
+                  센서 연결 상태를 확인한 뒤 다시 시도해주세요.
                 </p>
               </div>
             </div>
-          </div>
+          )}
 
-          {/* Recommended Times */}
-          <div className="mb-4">
-            <h3 className="font-['Noto_Sans_KR:Bold',_sans-serif] mb-3 text-foreground">추천시간</h3>
-            
-            <div className="grid grid-cols-2 gap-3">
+          {conditionsError && (
+            <p className="mt-4 font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-red-500">
+              {conditionsError}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Recommended Times */}
+      <div className="mb-4">
+        <h3 className="font-['Noto_Sans_KR:Bold',_sans-serif] mb-3 text-foreground">추천시간</h3>
+
+        <div className="grid grid-cols-2 gap-3">
               {/* Good Time */}
               <div className="bg-card dark:bg-gray-800 rounded-xl p-3 flex items-center gap-3 shadow-sm border border-border">
                 <div className="shrink-0 w-10 h-10 bg-blue-100 dark:bg-blue-900/50 rounded-full flex items-center justify-center">
@@ -540,9 +852,20 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
                   <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mb-0.5">
                     방문 추천
                   </p>
-                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[13px] text-foreground">
-                    16:00~18:00
-                  </p>
+                  {bestHour ? (
+                    <>
+                      <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[13px] text-foreground">
+                        {bestHourRange}
+                      </p>
+                      <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground">
+                        파고 {formatWaveHeight(bestHourWave)} · {bestHourStatus}
+                      </p>
+                    </>
+                  ) : (
+                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground">
+                      {recommendationFallback}
+                    </p>
+                  )}
                 </div>
               </div>
 
@@ -555,18 +878,29 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
                   <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mb-0.5">
                     혼잡 시간대
                   </p>
-                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[13px] text-foreground">
-                    12:00~14:00
-                  </p>
+                  {worstHour ? (
+                    <>
+                      <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[13px] text-foreground">
+                        {worstHourRange}
+                      </p>
+                      <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground">
+                        파고 {formatWaveHeight(worstHourWave)} · {worstHourStatus}
+                      </p>
+                    </>
+                  ) : (
+                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground">
+                      {recommendationFallback}
+                    </p>
+                  )}
                 </div>
               </div>
             </div>
           </div>
 
-          {/* 24-hour Congestion Prediction */}
+          {/* 24-hour Wave Height Trend */}
           <div>
             <div className="flex items-center justify-between mb-3">
-              <h3 className="font-['Noto_Sans_KR:Bold',_sans-serif] text-foreground">24시간 혼잡도 예측</h3>
+              <h3 className="font-['Noto_Sans_KR:Bold',_sans-serif] text-foreground">최근 24시간 파고 추이</h3>
               <div className="flex items-center gap-2">
                 <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse" />
                 <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground">
@@ -574,90 +908,133 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
                 </span>
               </div>
             </div>
-            
+
             <div className="bg-card dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-border">
-              {/* Legend at top */}
-              <div className="flex items-center justify-center gap-6 mb-4 pb-4 border-b border-border">
-                <div className="flex items-center gap-2">
-                  <div className="w-5 h-5 rounded-md" style={{ backgroundColor: statusColors.free }} />
-                  <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-foreground">여유 (0-40%)</span>
+              {isLoadingConditions && !hasHourlyObservations ? (
+                <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px]">
+                    그래프를 준비하는 중입니다...
+                  </span>
                 </div>
-                <div className="flex items-center gap-2">
-                  <div className="w-5 h-5 rounded-md" style={{ backgroundColor: statusColors.normal }} />
-                  <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-foreground">보통 (40-70%)</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="w-5 h-5 rounded-md" style={{ backgroundColor: statusColors.busy }} />
-                  <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-foreground">혼잡 (70-100%)</span>
-                </div>
-              </div>
+              ) : hasHourlyObservations ? (
+                <>
+                  {/* Legend at top */}
+                  <div className="flex flex-wrap items-center justify-center gap-4 mb-4 pb-4 border-b border-border">
+                    <div className="flex items-center gap-2">
+                      <div className="w-5 h-5 rounded-md" style={{ backgroundColor: statusColors.free }} />
+                      <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-foreground">여유 (&lt;0.4m)</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <div className="w-5 h-5 rounded-md" style={{ backgroundColor: statusColors.normal }} />
+                      <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-foreground">보통 (0.4~1.0m)</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <div className="w-5 h-5 rounded-md" style={{ backgroundColor: statusColors.busy }} />
+                      <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-foreground">혼잡 (≥1.0m)</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <div className="w-5 h-5 rounded-md" style={{ backgroundColor: statusColors.unknown }} />
+                      <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-foreground">데이터 없음</span>
+                    </div>
+                  </div>
 
-              {/* Chart */}
-              <div className="relative">
-                <div className="flex items-end justify-between gap-[2px] h-[180px]">
-                  {hourlyData.map((data) => {
-                    const isCurrentHour = data.hour === currentHour;
-                    const barHeight = (data.percentage / 100) * 160;
-                    
-                    return (
-                      <div 
-                        key={data.hour} 
-                        className="flex flex-col items-center gap-2 flex-1 relative group"
-                      >
-                        {/* Hover tooltip */}
-                        <div className="absolute bottom-full mb-2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
-                          <div className="bg-gray-900 text-white px-3 py-2 rounded-lg shadow-lg whitespace-nowrap">
-                            <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[12px]">
-                              {data.hour}시
-                            </p>
-                            <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px]">
-                              {getStatusLabel(data.status)} {data.percentage}%
-                            </p>
-                            <div 
-                              className="absolute left-1/2 -translate-x-1/2 -bottom-1 w-2 h-2 bg-gray-900 rotate-45"
-                            />
-                          </div>
-                        </div>
+                  {/* Chart */}
+                  <div className="relative">
+                    <div className="flex items-end justify-between gap-[2px] h-[180px]">
+                      {hourlyConditions.map((data) => {
+                        const isCurrentHour = data.hour === currentHour;
+                        const barHeight = (data.percentage / 100) * 160;
 
-                        {/* Bar */}
-                        <div 
-                          className="w-full rounded-t-md transition-all duration-300 hover:opacity-80 relative"
-                          style={{
-                            backgroundColor: statusColors[data.status],
-                            height: `${barHeight}px`,
-                            minHeight: '8px',
-                            boxShadow: isCurrentHour ? '0 0 0 2px #007DFC' : 'none',
-                          }}
-                        >
-                          {isCurrentHour && (
-                            <div className="absolute -top-6 left-1/2 -translate-x-1/2 whitespace-nowrap">
-                              <div className="bg-blue-500 text-white px-2 py-1 rounded text-[10px] font-['Noto_Sans_KR:Bold',_sans-serif]">
-                                지금
+                        return (
+                          <div
+                            key={data.hour}
+                            className="flex flex-col items-center gap-2 flex-1 relative group"
+                          >
+                            {/* Hover tooltip */}
+                            <div className="absolute bottom-full mb-2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                              <div className="bg-gray-900 text-white px-3 py-2 rounded-lg shadow-lg whitespace-nowrap">
+                                <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[12px]">
+                                  {data.hour}시
+                                </p>
+                                {data.waveHeight != null ? (
+                                  <>
+                                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px]">
+                                      파고 {formatWaveHeight(data.waveHeight)} · {getStatusLabel(data.status)}
+                                    </p>
+                                    {data.observedAt && (
+                                      <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[10px] text-gray-300 mt-1">
+                                        관측 {formatObservedAt(data.observedAt)}
+                                      </p>
+                                    )}
+                                  </>
+                                ) : (
+                                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px]">
+                                    데이터 없음
+                                  </p>
+                                )}
+                                <div className="absolute left-1/2 -translate-x-1/2 -bottom-1 w-2 h-2 bg-gray-900 rotate-45" />
                               </div>
                             </div>
-                          )}
-                        </div>
-                        
-                        {/* Hour label */}
-                        <span 
-                          className={`font-['Noto_Sans_KR:Medium',_sans-serif] text-[10px] ${
-                            isCurrentHour ? 'text-blue-600 dark:text-blue-400 font-bold' : 'text-muted-foreground'
-                          }`}
-                        >
-                          {data.hour}
-                        </span>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
 
-              {/* Time axis label */}
-              <div className="flex items-center justify-center mt-3 pt-3 border-t border-border">
-                <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground">
-                  시간대별 혼잡도 (0시 ~ 23시)
-                </span>
-              </div>
+                            {/* Bar */}
+                            <div
+                              className="w-full rounded-t-md transition-all duration-300 hover:opacity-80 relative"
+                              style={{
+                                backgroundColor: statusColors[data.status],
+                                height: `${barHeight}px`,
+                                minHeight: data.waveHeight != null ? '8px' : '6px',
+                                boxShadow: isCurrentHour ? '0 0 0 2px #007DFC' : 'none',
+                                opacity: data.waveHeight == null ? 0.3 : 1,
+                              }}
+                            >
+                              {isCurrentHour && (
+                                <div className="absolute -top-6 left-1/2 -translate-x-1/2 whitespace-nowrap">
+                                  <div className="bg-blue-500 text-white px-2 py-1 rounded text-[10px] font-['Noto_Sans_KR:Bold',_sans-serif]">
+                                    지금
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+
+                            {/* Hour label */}
+                            <span
+                              className={`font-['Noto_Sans_KR:Medium',_sans-serif] text-[10px] ${
+                                isCurrentHour
+                                  ? 'text-blue-600 dark:text-blue-400 font-bold'
+                                  : 'text-muted-foreground'
+                              }`}
+                            >
+                              {data.hour}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Time axis label */}
+                  <div className="flex items-center justify-center mt-3 pt-3 border-t border-border">
+                    <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground">
+                      시간대별 파고 (0시 ~ 23시)
+                    </span>
+                  </div>
+                </>
+              ) : (
+                <div className="flex flex-col items-center justify-center gap-3 py-10 text-center text-muted-foreground">
+                  <AlertTriangle className="w-6 h-6" />
+                  <div>
+                    <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[13px]">
+                      {isTelemetryConfigured
+                        ? '24시간 동안 수집된 파고 데이터가 없어요.'
+                        : '센서 연결을 기다리고 있어요.'}
+                    </p>
+                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground mt-1">
+                      실시간 데이터가 수집되면 그래프가 자동으로 업데이트돼요.
+                    </p>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 
@@ -668,7 +1045,7 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
               month={localDate?.getMonth() ? localDate.getMonth() + 1 : new Date().getMonth() + 1}
               year={localDate?.getFullYear() || new Date().getFullYear()}
               beachName={beach.name}
-              hourlyData={hourlyData}
+              hourlyData={heatmapHourlyData}
               onDateSelect={(date) => {
                 const newDate = new Date(date.year, date.month - 1, date.date);
                 setLocalDate(newDate);
@@ -698,42 +1075,75 @@ export function BeachDetailView({ beach, onClose, selectedDate, weatherTemp, onD
             <div className="bg-gradient-to-br from-blue-100 to-blue-50 p-6 rounded-full">
               <CloudWeatherIcon />
             </div>
-            <div className="text-center space-y-3">
-              <div>
-                <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-gray-600 mb-1">
-                  날씨
+            {isLoadingConditions && !latestCondition ? (
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px]">
+                  관측 데이터를 불러오는 중이에요...
+                </span>
+              </div>
+            ) : latestCondition ? (
+              <div className="text-center space-y-4 w-full">
+                <div>
+                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-gray-600 mb-1">
+                    날씨 요약
+                  </p>
+                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[16px] text-foreground">
+                    {weatherSummary}
+                  </p>
+                  {observedAtDisplay && (
+                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[12px] text-muted-foreground mt-1">
+                      관측 {observedAtDisplay}
+                    </p>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-3 gap-4 pt-2">
+                  <div>
+                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-gray-600 mb-1">
+                      수온
+                    </p>
+                    <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[14px] text-foreground">
+                      {formatWaterTemperature(latestWaterTemperature)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-gray-600 mb-1">
+                      파고
+                    </p>
+                    <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[14px] text-foreground">
+                      {waveHeightDisplay}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-gray-600 mb-1">
+                      현재 상태
+                    </p>
+                    <p
+                      className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[14px]"
+                      style={{ color: statusTextColor }}
+                    >
+                      {getStatusLabel(displayStatus)}
+                    </p>
+                  </div>
+                </div>
+
+                {observationLocation && (
+                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-muted-foreground">
+                    관측 위치 {observationLocation}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div className="text-center space-y-2 text-muted-foreground">
+                <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[13px]">
+                  표시할 관측 데이터가 아직 없어요.
                 </p>
-                <p className="font-['Noto_Sans_KR:Bold',_sans-serif]">
-                  {mockWeather.condition}
+                <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px]">
+                  센서가 데이터를 수집하면 자동으로 업데이트돼요.
                 </p>
               </div>
-              <div className="grid grid-cols-3 gap-4 pt-2">
-                <div>
-                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-gray-600 mb-1">
-                    기온
-                  </p>
-                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[14px]">
-                    {mockWeather.temp}
-                  </p>
-                </div>
-                <div>
-                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-gray-600 mb-1">
-                    습도
-                  </p>
-                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[14px]">
-                    {mockWeather.humidity}
-                  </p>
-                </div>
-                <div>
-                  <p className="font-['Noto_Sans_KR:Medium',_sans-serif] text-[11px] text-gray-600 mb-1">
-                    풍속
-                  </p>
-                  <p className="font-['Noto_Sans_KR:Bold',_sans-serif] text-[14px]">
-                    {mockWeather.wind}
-                  </p>
-                </div>
-              </div>
-            </div>
+            )}
           </div>
         </DialogContent>
       </Dialog>

--- a/front/src/data/beaches.ts
+++ b/front/src/data/beaches.ts
@@ -1,5 +1,6 @@
 export interface Beach {
-  id: number;
+  id: string;
+  apiId?: string;
   name: string;
   address: string;
   distance: string;
@@ -11,9 +12,20 @@ export interface Beach {
   };
 }
 
+const telemetryOverrides: Record<string, string | undefined> = {
+  haeundae: import.meta.env.VITE_BEACH_ID_HAEUNDAE as string | undefined,
+  gwanganli: import.meta.env.VITE_BEACH_ID_GWANGANLI as string | undefined,
+  songjeong: import.meta.env.VITE_BEACH_ID_SONGJEONG as string | undefined,
+  dadaepo: import.meta.env.VITE_BEACH_ID_DADAEPO as string | undefined,
+  songdo: import.meta.env.VITE_BEACH_ID_SONGDO as string | undefined,
+  ilgwang: import.meta.env.VITE_BEACH_ID_ILGWANG as string | undefined,
+  imrang: import.meta.env.VITE_BEACH_ID_IMRANG as string | undefined,
+};
+
 export const beaches: Beach[] = [
   {
-    id: 1,
+    id: 'haeundae',
+    apiId: telemetryOverrides.haeundae,
     name: '해운대해수욕장',
     address: '부산 해운대구',
     distance: '2.5km',
@@ -22,7 +34,8 @@ export const beaches: Beach[] = [
     mapPosition: { x: 70, y: 45 }, // 동쪽 중앙
   },
   {
-    id: 2,
+    id: 'gwanganli',
+    apiId: telemetryOverrides.gwanganli,
     name: '광안리해수욕장',
     address: '부산 수영구',
     distance: '3.2km',
@@ -31,7 +44,8 @@ export const beaches: Beach[] = [
     mapPosition: { x: 55, y: 50 }, // 중앙
   },
   {
-    id: 3,
+    id: 'songjeong',
+    apiId: telemetryOverrides.songjeong,
     name: '송정해수욕장',
     address: '부산 해운대구',
     distance: '5.8km',
@@ -40,7 +54,8 @@ export const beaches: Beach[] = [
     mapPosition: { x: 75, y: 30 }, // 동쪽 북쪽
   },
   {
-    id: 4,
+    id: 'dadaepo',
+    apiId: telemetryOverrides.dadaepo,
     name: '다대포해수욕장',
     address: '부산 사하구',
     distance: '12.3km',
@@ -49,7 +64,8 @@ export const beaches: Beach[] = [
     mapPosition: { x: 20, y: 70 }, // 서쪽 남쪽
   },
   {
-    id: 5,
+    id: 'songdo',
+    apiId: telemetryOverrides.songdo,
     name: '송도해수욕장',
     address: '부산 서구',
     distance: '8.1km',
@@ -58,7 +74,8 @@ export const beaches: Beach[] = [
     mapPosition: { x: 35, y: 55 }, // 중앙 서쪽
   },
   {
-    id: 6,
+    id: 'ilgwang',
+    apiId: telemetryOverrides.ilgwang,
     name: '일광해수욕장',
     address: '부산 기장군',
     distance: '15.6km',
@@ -67,7 +84,8 @@ export const beaches: Beach[] = [
     mapPosition: { x: 80, y: 20 }, // 동쪽 최북단
   },
   {
-    id: 7,
+    id: 'imrang',
+    apiId: telemetryOverrides.imrang,
     name: '임랑해수욕장',
     address: '부산 기장군',
     distance: '18.2km',


### PR DESCRIPTION
## Summary
- add a typed API helper that reuses the shared Basic auth flow to load recent beach conditions
- store optional telemetry identifiers for static beaches so the detail view can look up live data
- replace the mock congestion/weather UI with real telemetry snapshots, derived congestion colors, and empty/loading states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef3a426550833094e54c9fd2972393