### PR TITLE
fix(fe): robust updatedAt parsing (epoch s/ms/ISO) + guard unrealistic values

### DIFF
--- a/front/src/components/BeachCard.tsx
+++ b/front/src/components/BeachCard.tsx
@@ -32,22 +32,72 @@ const formatCoordinates = (latitude: number, longitude: number) => {
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
     return '좌표 정보 없음';
   }
-
   return `${latitude.toFixed(3)}°, ${longitude.toFixed(3)}°`;
 };
 
-const formatUpdatedAt = (updatedAt: string) => {
-  if (!updatedAt) {
-    return '업데이트 정보 없음';
-  }
+/* ---------- 날짜 유틸(교체본) ---------- */
+const EPOCH_MIN_SECONDS = 946684800;      // 2000-01-01T00:00:00Z
+const EPOCH_MAX_SECONDS = 4102444800;     // 2100-01-01T00:00:00Z
 
-  const parsed = new Date(updatedAt);
-  if (Number.isNaN(parsed.getTime())) {
-    return '업데이트 정보 없음';
-  }
-
-  return `업데이트: ${parsed.toLocaleString('ko-KR')}`;
+const normalizeToDate = (ms: number): Date | null => {
+  if (!Number.isFinite(ms)) return null;
+  const sec = ms / 1000;
+  // 2000~2100 사이만 유효로 본다. (백엔드 이상값 방어)
+  if (sec < EPOCH_MIN_SECONDS || sec > EPOCH_MAX_SECONDS) return null;
+  const d = new Date(ms);
+  return isNaN(d.getTime()) ? null : d;
 };
+
+const parseApiDate = (
+  value: number | string | Date | null | undefined
+): Date | null => {
+  if (value == null) return null;
+
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : normalizeToDate(value.getTime());
+  }
+
+  if (typeof value === 'number') {
+    if (value <= 0) return null; // 0/음수는 없음 처리
+    const ms = value < 1e12 ? value * 1000 : value; // 1e12 미만 → epoch seconds로 간주
+    return normalizeToDate(ms);
+  }
+
+  // "1709459200" 같은 숫자 문자열도 처리
+  if (/^\d+$/.test(value)) {
+    const n = Number(value);
+    if (n <= 0) return null;
+    const ms = n < 1e12 ? n * 1000 : n;
+    return normalizeToDate(ms);
+  }
+
+  // ISO 등 일반 문자열
+  const t = Date.parse(value);
+  if (Number.isNaN(t)) return null;
+  return normalizeToDate(t);
+};
+
+const formatUpdatedAt = (
+  raw: number | string | Date | null | undefined
+): string => {
+  const date = parseApiDate(raw);
+  if (!date) return '업데이트 정보 없음';
+
+  const text = new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+  }).format(date);
+
+  return `업데이트: ${text}`;
+};
+/* -------------------------------------- */
+
 
 export function BeachCard({ beach, onClick, isFavorite, onFavoriteToggle }: BeachCardProps) {
   const statusColor = statusColors[beach.status] ?? statusColors.unknown;
@@ -79,8 +129,8 @@ export function BeachCard({ beach, onClick, isFavorite, onFavoriteToggle }: Beac
           <p className="font-['Noto_Sans_KR:Regular',_sans-serif] text-[12px] text-muted-foreground truncate">
             {beach.code || '코드 정보 없음'} · {formatCoordinates(beach.latitude, beach.longitude)}
           </p>
-          <p className="font-['Noto_Sans_KR:Regular',_sans-serif] text-[11px] text-muted-foreground truncate">
-            {formatUpdatedAt(beach.updatedAt)}
+          <p className="font-['Noto_SANS_KR:Regular',_sans-serif] text-[11px] text-muted-foreground truncate">
+            {formatUpdatedAt((beach as any).updatedAt)}
           </p>
         </div>
       </div>

--- a/front/src/types/beach.ts
+++ b/front/src/types/beach.ts
@@ -7,7 +7,7 @@ export interface Beach {
   status: BeachStatus;
   latitude: number;
   longitude: number;
-  updatedAt: string | number;
+  updatedAt?: number | string;
 
   tag?: string | null;
   isFavorite?: boolean;

--- a/front/src/utils/time.ts
+++ b/front/src/utils/time.ts
@@ -1,0 +1,50 @@
+export function parseApiDate(
+  value: number | string | Date | null | undefined
+): Date | null {
+  if (value == null) return null;
+
+  // Date 인스턴스 그대로
+  if (value instanceof Date) return isNaN(value.getTime()) ? null : value;
+
+  // 숫자 → epoch seconds/ms 구분
+  if (typeof value === 'number') {
+    const ms = value < 1e12 ? value * 1000 : value; // 1e12 미만이면 seconds로 간주
+    const d = new Date(ms);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  // 숫자 문자열 → epoch seconds/ms 구분
+  if (/^\d+$/.test(value)) {
+    const n = Number(value);
+    const ms = n < 1e12 ? n * 1000 : n;
+    const d = new Date(ms);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  // ISO 등 일반 문자열
+  const t = Date.parse(value);
+  if (Number.isNaN(t)) return null;
+  const d = new Date(t);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+export function formatKST(date: Date | null): string {
+  if (!date) return '업데이트 정보 없음';
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+  }).format(date);
+}
+
+/** API 원시값(updatedAt 등)을 안전하게 포맷 */
+export function formatUpdatedAt(
+  raw: number | string | Date | null | undefined
+): string {
+  return formatKST(parseApiDate(raw));
+}


### PR DESCRIPTION
Closes #23
### 현상
- 목록 카드에서 `업데이트: 1970-..`처럼 비정상 시간 표시가 발생.

### 원인 가설
- 백엔드가 epoch **seconds** 또는 비정상(0/매우 작은 값)을 내려줄 때 FE가 그대로 Date 변환 → 1970 표기.
- 형식 혼재(ISO, seconds, milliseconds)가 공존.

### 기대 동작
- ISO 또는 epoch **milliseconds** 기준으로 일관 포맷.
- 비현실 범위(< 2000-01-01 or > 2100-01-01)나 0/음수는 ‘업데이트 정보 없음’.

### 완료 조건(AC)
- [x] 초/밀리초/ISO 모두 정상 포맷 (Asia/Seoul).
- [x] 0/음수/비현실 범위는 ‘업데이트 정보 없음’.
- [x] 동일 표기를 쓰는 화면 전역 재현 방지.

### 비고
- PR #24에서 FE 방어로 1차 해결.
- BE는 `updatedAt` 포맷 표준화(ISO or epoch ms)로 후속 조치 필요.
