### PR TITLE
[FE/Feat] PB-35: 사용자 위치 기반 검색 구현

### DIFF
--- a/front/src/components/BeachDetailView.tsx
+++ b/front/src/components/BeachDetailView.tsx
@@ -9,6 +9,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
 import { Toaster } from './ui/sonner';
 import { fetchRecentConditions, type BeachConditionDto } from '../api/conditions';
 import MapView from '@/components/MapView';
+import { useUserLocation } from '../hooks/useUserLocation'; // ✅ 추가
 
 interface BeachDetailViewProps {
   beach: Beach;
@@ -166,6 +167,9 @@ export function BeachDetailView({
   const [isLoadingConditions, setIsLoadingConditions] = useState(false);
   const [conditionsError, setConditionsError] = useState<string | null>(null);
   const beachTelemetryId = beach.id || null;
+
+  // ✅ 사용자 위치 가져오기
+  const { coords } = useUserLocation();
 
   useEffect(() => {
     let ignore = false;
@@ -465,6 +469,7 @@ export function BeachDetailView({
           beaches={allBeaches}
           selected={beach}
           onSelect={(b) => onBeachChange?.(b)}
+          userCoords={coords} // ✅ 사용자 위치 전달
         />
       </div>
 

--- a/front/src/components/MapView.tsx
+++ b/front/src/components/MapView.tsx
@@ -1,4 +1,4 @@
-import { MapContainer, TileLayer, CircleMarker, Popup, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, CircleMarker, Marker, Popup, useMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { Beach } from '@/types/beach';
 import L from 'leaflet';
@@ -12,6 +12,15 @@ L.Icon.Default.mergeOptions({
   shadowUrl:     new URL('leaflet/dist/images/marker-shadow.png', import.meta.url).toString(),
 });
 
+// ✅ 사용자 위치 마커 아이콘 (파란색)
+const userLocationIcon = new L.Icon({
+  iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41]
+});
 
 const statusColor = (s: Beach['status']) =>
   s === 'busy' ? '#ef4444' : s === 'normal' ? '#f59e0b' : s === 'free' ? '#22c55e' : '#64748b';
@@ -26,9 +35,10 @@ type Props = {
   beaches: Beach[];
   selected?: Beach | null;
   onSelect?: (b: Beach) => void;
+  userCoords?: { lat: number; lng: number } | null; // ✅ 사용자 위치 추가
 };
 
-export default function MapView({ beaches, selected, onSelect }: Props) {
+export default function MapView({ beaches, selected, onSelect, userCoords }: Props) {
   const center: [number, number] =
     selected
       ? [selected.latitude, selected.longitude]
@@ -50,6 +60,22 @@ export default function MapView({ beaches, selected, onSelect }: Props) {
 
       {selected && <FlyTo center={[selected.latitude, selected.longitude]} />}
 
+      {/* ✅ 사용자 위치 마커 */}
+      {userCoords && (
+        <Marker
+          position={[userCoords.lat, userCoords.lng]}
+          icon={userLocationIcon}
+        >
+          <Popup>
+            <div style={{ fontWeight: 600 }}>내 위치</div>
+            <div style={{ fontSize: 12, color: '#64748b' }}>
+              {userCoords.lat.toFixed(4)}, {userCoords.lng.toFixed(4)}
+            </div>
+          </Popup>
+        </Marker>
+      )}
+
+      {/* 해수욕장 마커들 */}
       {beaches.map((b) => (
         <CircleMarker
           key={b.id}


### PR DESCRIPTION
## 🧩 한눈에 요약 (필수)
### 무엇을 추가/변경했나?
- 앱 접속 시 사용자 위치를 자동으로 획득하여 반경 50km 이내 해수욕장을 자동 검색
- 각 해수욕장 카드에 현재 위치로부터의 거리 표시 (예: "3.2km")
- 지도에 사용자 위치 마커 추가 (파란색 핀)
- 위치 권한 상태별 UI 처리 (로딩, 거부, 허용)

### 왜 필요한가? (User value / problem)
- **문제**: 사용자가 수동으로 해수욕장을 검색하거나 목록을 스크롤하며 찾아야 하는 불편함
- **가치**: 앱 접속 즉시 내 주변 해수욕장을 자동으로 보여줘 검색 시간 단축 (30초~1분 → 0초)
- **효과**: 거리 정보 제공으로 방문 계획 수립 용이, 지도에서 공간적 관계 직관적 파악 가능

### 범위(스코프)
- **Included**:
  - 위치 기반 자동 검색 (50km 고정)
  - 해수욕장 카드에 거리 표시
  - 지도 사용자 위치 마커
  - 위치 권한 상태별 UI
- **Not included**:
  - 검색 반경 조절 기능 (Phase 2)
  - 수동 위치 입력 (Phase 2)
  - 위치 재검색 버튼 (Phase 2)
  - 백엔드 API 변경 (기존 API 활용)

---

## 🧱 설계/접근 (권장)
- **핵심 아이디어**:
  - 기존 `useUserLocation` hook과 거리 기반 검색 API 활용
  - 프론트엔드에서 Haversine 공식으로 UI 표시용 거리 계산
  - 백엔드 PostGIS는 반경 필터링 및 정렬만 담당 (API 응답에 거리 값 미포함)

- **주요 컴포넌트/모듈**:
  - `App.tsx`: 위치 획득 시 자동 검색 로직, 권한 상태별 UI 렌더링
  - `MapView.tsx`: 사용자 위치 마커 렌더링 (Leaflet Marker)
  - `BeachDetailView.tsx`: 상세 화면 지도에 사용자 위치 전달
  - `BeachCard.tsx`: Haversine 공식으로 거리 계산 및 표시 (기존 코드 활용)

- **데이터 흐름/상태 변화**:
  ```
  useUserLocation hook → coords 획득
    ↓
  App.tsx useEffect 트리거
    ↓
  /api/beaches?lat=X&lon=Y&radiusKm=50 호출
    ↓
  Beach[] 응답 → setBeaches
    ↓
  BeachCard에 userCoords 전달 → 거리 계산 및 표시
    ↓
  MapView에 userCoords 전달 → 파란색 마커 표시
  ```

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] **AC1**: 위치 권한 허용 시, 현재 위치 기준 50km 이내 해수욕장이 자동 검색되고 거리가 카드에 표시된다
- [x] **AC2**: 위치 권한 거부 시, 안내 메시지가 표시되고 대체 위치(부산시청)로 검색된다
- [x] **AC3**: 지도에 사용자 위치가 파란색 마커로 표시되며, 클릭 시 좌표 팝업이 표시된다
- [x] **AC4**: 위치 정보 로딩 중 "위치 정보를 가져오는 중..." UI가 표시된다
- [x] **AC5**: API 호출 실패 시 에러 메시지가 표시된다


---

## 🧪 테스트 / 검증 (필수)
### 로컬
- **Command**: `cd front && npm run dev`
- **Result**:
  - ✅ 위치 권한 허용 시 부산 해수욕장 목록 자동 표시
  - ✅ 각 카드에 거리 표시 확인 (예: "3.2km")
  - ✅ 지도에 파란색 마커 표시 확인
  - ✅ 위치 권한 거부 시 안내 UI 및 대체 위치 검색 확인

### CI
- 링크/결과: (CI 설정 시 자동 첨부)

### Smoke / 수동 검증
- **시나리오**:
  1. 앱 접속 → 위치 권한 허용 → 주변 해수욕장 목록 확인
  2. 각 카드의 거리 표시 확인
  3. 지도에서 내 위치 마커 확인
  4. 상세 화면 진입 → 지도에 내 위치 마커 확인
  5. 브라우저 설정에서 위치 권한 차단 → 새로고침 → 안내 메시지 및 대체 검색 확인
- **결과**: ✅ 모든 시나리오 정상 동작

### 테스트 공백(있다면 이유 필수)
- 자동화된 단위/통합 테스트는 추후 추가 예정 (현재는 수동 검증으로 대체)


---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )
- [ ] UX/UI 변경 없음
- [x] UX/UI 변경 있음
  - 위치 권한 로딩/거부 시 안내 UI 추가
  - 해수욕장 카드에 거리 표시 추가
  - 지도에 사용자 위치 마커 추가

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:


---

## 🚀 롤아웃/관측 (권장)
### Feature Flag / 단계적 배포
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 측정(있다면)
- **성공 지표/메트릭**:
  - 앱 첫 로딩 후 검색까지 걸리는 시간 (목표: 3초 이내)
  - 위치 권한 허용률 모니터링
- **이벤트/로그 추가 여부**:
  - 콘솔 로그 추가: 위치 정보, API 요청, 검색 결과 수

### 모니터링/알림
- **확인할 대시보드/지표**:
  - `/api/beaches` API 호출 빈도 및 응답 시간
  - 위치 파라미터 포함 요청 비율
- **에러/로그 키워드**:
  - "위치 정보를 불러오지 못했습니다"
  - "해수욕장 정보를 불러오지 못했습니다"

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- **리스크 1**: 사용자가 부산 외 지역에 있을 경우 검색 결과 없음
  - **완화**: "검색 결과가 없습니다" 메시지 표시, Phase 2에서 반경 확대 옵션 제공
- **리스크 2**: 위치 권한 거부율이 높을 수 있음
  - **완화**: 거부 시에도 대체 위치(부산시청)로 검색하여 기본 기능 제공
- **리스크 3**: 위치 정보 획득 실패 (GPS 오류, 타임아웃)
  - **완화**: useUserLocation hook에서 에러 시 fallback 위치 사용

### 롤백
- [x] 플래그/설정으로 우회 가능 (위치 거부 시 대체 위치 사용)
- [x] 배포 롤백(이전 태그/이미지) 가능
- [x] 데이터 롤백/역마이그레이션 필요 없음 (DB 변경 없음)


---

## 📸 증빙 (선택)
- **스크린샷**:
<img width="1092" height="1551" alt="image (1)" src="https://github.com/user-attachments/assets/25b437c1-3c37-4efc-9caa-3d0aa5d91dab" />
  - 위치 권한 허용 시 검색 결과 (거리 표시 포함)
  - 지도 사용자 위치 마커 (파란색 핀)
  - 위치 권한 거부 시 안내 UI

---

## 💬 리뷰 가이드 (필수)
### 꼭 봐야 하는 파일/로직
- **`front/src/App.tsx:125-176`**: 위치 기반 자동 검색 로직 (`useEffect`)
- **`front/src/App.tsx:424-457`**: 위치 권한 상태별 UI 렌더링
- **`front/src/components/MapView.tsx:15-23, 64-76`**: 사용자 위치 마커 정의 및 렌더링
- **`front/src/components/BeachDetailView.tsx`**: useUserLocation hook 사용 및 MapView 전달

### 트레이드오프/대안
- **현재 방식**: 프론트엔드에서 Haversine 공식으로 거리 계산
  - 장점: 백엔드 변경 불필요, 빠른 구현
  - 단점: 중복 계산 (백엔드도 PostGIS로 거리 계산), 정확도 약간 낮음
- **대안 (Phase 2)**: 백엔드 API 응답에 `distanceMeters` 필드 추가
  - 장점: 정확도 향상, 중복 계산 제거
  - 단점: 백엔드 수정 필요

### 성능/보안/호환성 영향
- **성능**:
  - Haversine 계산은 클라이언트에서 수행하므로 서버 부하 없음
  - API 호출은 위치 획득 시 1회만 발생
- **보안**:
  - 사용자 위치 정보는 localStorage에 저장하지 않음 (매번 새로 요청)
  - HTTPS 환경에서만 Geolocation API 사용 가능
- **호환성**:
  - 모던 브라우저 Geolocation API 지원 (Chrome, Firefox, Safari, Edge)
  - 위치 권한 거부 시에도 대체 위치로 동작하여 Graceful degradation 보장