### PR TITLE
[test] PB-90 (01/03) 이메일 전송  AFTER_COMMIT + verify/resend 상태 전이

### DIFF
--- a/src/test/java/com/beachcheck/integration/EmailAfterCommitIntegrationTest.java
+++ b/src/test/java/com/beachcheck/integration/EmailAfterCommitIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.beachcheck.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+import com.beachcheck.base.IntegrationTest;
+import com.beachcheck.domain.User;
+import com.beachcheck.repository.EmailVerificationTokenRepository;
+import com.beachcheck.repository.UserRepository;
+import com.beachcheck.service.AsyncEmailService;
+import com.beachcheck.service.EmailVerificationService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class EmailAfterCommitIntegrationTest extends IntegrationTest {
+
+  @Autowired private EmailVerificationService emailVerificationService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private EmailVerificationTokenRepository tokenRepository;
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @MockBean private AsyncEmailService asyncEmailService;
+
+  private final List<UUID> createdUserIds = new ArrayList<>();
+  private TransactionTemplate transactionTemplate;
+
+  @BeforeEach
+  void setUpTransactionTemplate() {
+    transactionTemplate = new TransactionTemplate(transactionManager);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    transactionTemplate.executeWithoutResult(
+        unused -> {
+          if (!createdUserIds.isEmpty()) {
+            entityManager
+                .createQuery("delete from EmailVerificationToken t where t.user.id in :userIds")
+                .setParameter("userIds", createdUserIds)
+                .executeUpdate();
+            userRepository.deleteAllByIdInBatch(createdUserIds);
+          }
+        });
+    createdUserIds.clear();
+  }
+
+  @Test
+  @DisplayName("커밋 후 이메일 비동기 전송이 호출된다")
+  void sendVerification_afterCommit_triggersListener() {
+    // given
+    User user = saveUser();
+
+    // when
+    transactionTemplate.executeWithoutResult(
+        unused -> {
+          User managedUser = userRepository.findById(user.getId()).orElseThrow();
+          emailVerificationService.sendVerification(managedUser);
+
+          // 트랜잭션 내부에서는 AFTER_COMMIT 리스너가 아직 동작하지 않아야 한다.
+          then(asyncEmailService).shouldHaveNoInteractions();
+        });
+
+    ArgumentCaptor<String> emailCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> linkCaptor = ArgumentCaptor.forClass(String.class);
+    then(asyncEmailService)
+        .should()
+        .sendVerificationEmailAsync(emailCaptor.capture(), linkCaptor.capture());
+
+    // then
+    assertThat(emailCaptor.getValue()).isEqualTo(user.getEmail());
+    assertThat(linkCaptor.getValue()).contains("?token=");
+    assertThat(tokenRepository.findTopByUserIdOrderByCreatedAtDesc(user.getId())).isPresent();
+  }
+
+  @Test
+  @DisplayName("롤백 시 이메일 비동기 전송이 호출되지 않는다")
+  void sendVerification_rollback_doesNotTriggerListener() {
+    // given
+    User user = saveUser();
+
+    // when
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          User managedUser = userRepository.findById(user.getId()).orElseThrow();
+          emailVerificationService.sendVerification(managedUser);
+          status.setRollbackOnly();
+        });
+
+    // then
+    then(asyncEmailService).shouldHaveNoInteractions();
+    assertThat(tokenRepository.findTopByUserIdOrderByCreatedAtDesc(user.getId())).isEmpty();
+  }
+
+  private User saveUser() {
+    User user = new User();
+    user.setEmail("after-commit-" + UUID.randomUUID() + "@test.com");
+    user.setName("after-commit-tester");
+    user.setPassword("encoded-password");
+    user.setEnabled(false);
+    user.setRole(User.Role.USER);
+    user.setAuthProvider(User.AuthProvider.EMAIL);
+
+    User saved = userRepository.save(user);
+    createdUserIds.add(saved.getId());
+    return saved;
+  }
+}

--- a/src/test/java/com/beachcheck/integration/EmailVerificationStateTransitionIntegrationTest.java
+++ b/src/test/java/com/beachcheck/integration/EmailVerificationStateTransitionIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.beachcheck.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.beachcheck.base.IntegrationTest;
+import com.beachcheck.domain.EmailVerificationToken;
+import com.beachcheck.domain.User;
+import com.beachcheck.repository.EmailVerificationTokenRepository;
+import com.beachcheck.repository.UserRepository;
+import com.beachcheck.service.EmailVerificationService;
+import com.beachcheck.util.HashUtils;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = "app.email-verification.resend-cooldown-minutes=0")
+class EmailVerificationStateTransitionIntegrationTest extends IntegrationTest {
+
+  private static final long NON_EXPIRED_TOKEN_DAYS = 1L;
+
+  @Autowired private EmailVerificationService emailVerificationService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private EmailVerificationTokenRepository tokenRepository;
+
+  @Test
+  @DisplayName("유효 토큰 검증 시 사용자 활성화되고 토큰은 사용 처리된다")
+  void verifyToken_validToken_updatesUserAndToken() {
+    // given
+    User user = saveDisabledUser("verify-" + UUID.randomUUID() + "@test.com");
+
+    String rawToken = "raw-token-" + UUID.randomUUID();
+    String hashed = HashUtils.sha256Hex(rawToken);
+    EmailVerificationToken token =
+        new EmailVerificationToken(
+            user, hashed, Instant.now().plus(NON_EXPIRED_TOKEN_DAYS, ChronoUnit.DAYS));
+    tokenRepository.save(token);
+    entityManager.flush();
+    entityManager.clear();
+
+    // when
+    emailVerificationService.verifyToken(rawToken);
+    entityManager.flush();
+    entityManager.clear();
+
+    User verifiedUser = userRepository.findById(user.getId()).orElseThrow();
+    EmailVerificationToken usedToken = tokenRepository.findByToken(hashed).orElseThrow();
+
+    // then
+    assertThat(verifiedUser.getEnabled()).isTrue();
+    assertThat(usedToken.getUsedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("재전송 시 기존 미사용 토큰은 사용 처리되고 신규 토큰이 생성된다")
+  void resendVerification_marksOldTokenUsedAndCreatesNewToken() {
+    // given
+    User user = saveDisabledUser("resend-" + UUID.randomUUID() + "@test.com");
+
+    String oldRawToken = "old-token-" + UUID.randomUUID();
+    String oldHashedToken = HashUtils.sha256Hex(oldRawToken);
+    EmailVerificationToken oldToken =
+        new EmailVerificationToken(
+            user, oldHashedToken, Instant.now().plus(NON_EXPIRED_TOKEN_DAYS, ChronoUnit.DAYS));
+    tokenRepository.save(oldToken);
+    entityManager.flush();
+    entityManager.clear();
+
+    // when
+    emailVerificationService.resendVerification(user.getEmail());
+    entityManager.flush();
+    entityManager.clear();
+
+    EmailVerificationToken previousToken =
+        tokenRepository.findByToken(oldHashedToken).orElseThrow();
+    EmailVerificationToken reissuedToken =
+        tokenRepository.findTopByUserIdOrderByCreatedAtDesc(user.getId()).orElseThrow();
+
+    // then
+    assertThat(previousToken.getToken()).isEqualTo(oldHashedToken);
+    assertThat(previousToken.getUsedAt()).isNotNull();
+
+    assertThat(reissuedToken.getId()).isNotEqualTo(previousToken.getId());
+    assertThat(reissuedToken.getToken()).isNotEqualTo(oldHashedToken);
+    assertThat(reissuedToken.getUsedAt()).isNull();
+  }
+
+  private User saveDisabledUser(String email) {
+    User user = new User();
+    user.setEmail(email);
+    user.setName("verification-state-tester");
+    user.setPassword("encoded-password");
+    user.setEnabled(false);
+    user.setRole(User.Role.USER);
+    user.setAuthProvider(User.AuthProvider.EMAIL);
+    return userRepository.save(user);
+  }
+}


### PR DESCRIPTION
# 🧪 Test PR

## 🔗 이슈 링크 (필수)
- Jira: https://parkjaehong.atlassian.net/browse/PB-90
- GitHub: Related #187
- GitHub: Closes #N/A (Stacked PR 1단계)

> PR 제목: `[test] PB-90 (01/03) 이메일 전송 AFTER_COMMIT + verify/resend 상태 전이`

---

## 🧾 이 PR의 테스트 범위 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 PB-90의 1/3 단계
- 선행 PR: 없음 (`main` 기준 첫 스택)

### 변경/추가 테스트 상세
- [x] 신규 테스트 추가
  - Unit: 0개
  - Integration: 2개 시나리오 (TC1/TC2 핵심 흐름, 테스트 메서드 4개)
  - E2E: 0개
- [ ] 기존 테스트 수정
- [ ] 테스트 삭제
- [x] 테스트 유틸/픽스처 변경
  - `HashTestUtils` 추가로 해시 계산 로직 공통화

### 대상 모듈/시나리오
1. `EmailAfterCommitIntegrationTest`
2. `EmailVerificationStateTransitionIntegrationTest`

---

## 이 PR이 커버하는 TC (필수)
### Covers (이 PR에서 구현)
- TC1: `EmailEventListener` AFTER_COMMIT 경계 검증
  - 커밋 시 비동기 전송 호출
  - 롤백 시 호출 없음
- TC2: `EmailVerificationService` verify/resend 상태 전이 검증 (핵심 경로)
  - verify 성공 시 `user.enabled=true`, `token.usedAt` 설정
  - resend 시 기존 토큰 사용처리 + 신규 토큰 생성

### Not covered (후속 작업)
- TC3: `SmtpEmailSender`/`NoopEmailSender` 조건부 빈 선택 검증  
  - 후속 PR #2
- TC4: `AsyncEmailService @Retryable` 실동작 검증  
  - 후속 PR #3

---

## 테스트 실행 결과 (필수)
### 로컬
```bash
./gradlew.bat spotlessJavaCheck
./gradlew.bat test --tests com.beachcheck.integration.EmailAfterCommitIntegrationTest --tests com.beachcheck.integration.EmailVerificationStateTransitionIntegrationTest
./gradlew.bat test --tests com.beachcheck.service.AuthServiceTest --tests com.beachcheck.integration.EmailAfterCommitIntegrationTest --tests com.beachcheck.integration.EmailVerificationStateTransitionIntegrationTest
```
- 결과: 통과

### CI
- (자동 첨부)

---

## 🌐 영향 범위 체크 (필수)
- [x] 런타임 코드 변경
  - `EmailVerificationTokenRepository` 메서드 추가
    - `findTopByUserIdAndUsedAtIsNullOrderByCreatedAtDescIdDesc`
    - `deleteByUserIds`
  - `EmailVerificationService` SHA-256 hex 변환 로직 개선 (`HexFormat`)
- [ ] DB/마이그레이션 변경
- [ ] CI 파이프라인 변경
- [ ] 플래키 테스트
- 테스트 환경/설정 변경: 없음 (PR3에서 retry 관련 설정 예정)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 테스트/로직:
  - `@TransactionalEventListener(AFTER_COMMIT)` 경계 검증 방식
  - 클래스 레벨 `NOT_SUPPORTED` + `TransactionTemplate` 사용 의도
  - 전역 `count/findAll` 의존 제거 후 범위 제한 검증 방식
- 트레이드오프:
  - 이슈 계획상 PR1은 통합테스트 중심이지만, 실제 구현에서는 테스트 안정화 목적의 최소 런타임 보강(Repository/해시 변환)을 포함
  - 대안(테스트 코드만 복잡화) 대비 유지보수성/명확성 우선 선택
