### PR TITLE
[test] PB-90 (02/03) 이메일 전송 빈 선택 통합테스트 추가

### DIFF
--- a/src/test/java/com/beachcheck/config/EmailSenderBeanSelectionConditionTest.java
+++ b/src/test/java/com/beachcheck/config/EmailSenderBeanSelectionConditionTest.java
@@ -1,4 +1,4 @@
-package com.beachcheck.integration;
+package com.beachcheck.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -14,8 +14,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.mail.javamail.JavaMailSender;
 
-@DisplayName("EmailSender 조건부 빈 선택 통합 테스트")
-class EmailSenderBeanSelectionIntegrationTest {
+@DisplayName("EmailSender 조건부 빈 선택 컨텍스트 테스트")
+class EmailSenderBeanSelectionConditionTest {
 
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()


### PR DESCRIPTION
# 🧪 Test PR

## 🔗 이슈 링크 (필수)
- Jira: https://parkjaehong.atlassian.net/browse/PB-90
- GitHub: Related #187
- GitHub: Closes #N/A (Stacked PR 2단계)

> PR 제목: `[test] PB-90 (02/03) 이메일 전송 빈 선택 통합테스트 추가`

---

## 🧾 이 PR의 테스트 범위 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 PB-90의 2/3 단계
- 선행 PR: #189

### 변경/추가 테스트 상세
- [x] 신규 테스트 추가
  - Unit: 0개
  - Integration: 1개 시나리오 (1개 시나리오 / 4개 테스트 메서드)
  - E2E: 0개
- [ ] 기존 테스트 수정
- [ ] 테스트 삭제
- [ ] 테스트 데이터/픽스처 변경

### 대상 모듈/시나리오
1. `EmailSender` 조건부 빈 선택 (`NoopEmailSender` / `SmtpEmailSender`)
2. `app.mail.enabled`, `app.mail.default-from` 조합별 컨텍스트 동작

---

## 이 PR이 커버하는 TC (필수)
### Covers (이 PR에서 구현)
- TC3: `SmtpEmailSender`/`NoopEmailSender` 설정 기반 빈 선택 검증
  - 정상 케이스: `enabled=false` -> `NoopEmailSender` 등록
  - 정상 케이스: `enabled=true` + `default-from` 유효 -> `SmtpEmailSender` 등록
  - 예외 케이스: `enabled=true` + `default-from` 공백 -> 컨텍스트 기동 실패
  - 경계값 케이스: `enabled` 미설정 -> `NoopEmailSender(matchIfMissing=true)` 등록

### Not covered (후속 작업)
- TC4: `AsyncEmailService @Retryable` 실동작 검증  
  - 후속 PR  PB-90 PR3 예정

---

## 테스트 실행 결과 (필수)
### 로컬
```bash
./gradlew.bat spotlessJavaCheck
./gradlew.bat test --tests com.beachcheck.integration.EmailSenderBeanSelectionIntegrationTest
```
- 결과: 통과 (4개 케이스)

### CI
- (자동 첨부)

---

## 🌐 영향 범위 체크 (필수)
- [ ] 런타임 코드 변경 (요약: )
- [ ] DB/마이그레이션 변경 (요약: )
- [ ] CI 파이프라인 변경 (요약: )
- [ ] 플래키 테스트 (원인/대응: )
- [x] 테스트 전용 컨텍스트 검증 추가 (`ApplicationContextRunner)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 테스트/로직:
  - `@ConditionalOnProperty`(`havingValue`, `matchIfMissing`) 계약 검증 범위가 충분한지
    - `enabled=false` -> `NoopEmailSender`
    - `enabled=true` + 유효한 `default-from` -> `SmtpEmailSender`
    - `enabled` 미설정 -> `NoopEmailSender(matchIfMissing=true)`
  - `enabled=true` + `default-from` 공백 시 실패가 의도한 fail-fast인지
    - `ApplicationContext` 기동 실패 여부
    - root cause `IllegalArgumentException` 및 메시지(`app.mail.default-from이 설정되어야 합니다.`) 검증
  - `ApplicationContextRunner` 기반 최소 컨텍스트에서 케이스 간 간섭이 없는지
    - 케이스별 `withPropertyValues`로 독립 실행
    - 필요 케이스에만 `JavaMailSender` mock 주입
    - 실행 순서와 무관하게 동일 결과가 나는지

- 트레이드오프:
  - 전역 `application-test.yml` 수정 없이 `withPropertyValues`로 조합 검증하여 영향 범위를 최소화
  - 컨텍스트 기동 실패 케이스를 별도 테스트 컨텍스트로 분리해 가독성과 실패 원인 식별성을 우선
