### PR TITLE
[feat] PB-88 (4/5) FCM 에러 코드 기반 영구 실패 분류 기능 구현

### DIFF
--- a/src/main/java/com/beachcheck/service/OutboxEventDispatcher.java
+++ b/src/main/java/com/beachcheck/service/OutboxEventDispatcher.java
@@ -8,6 +8,7 @@ import com.beachcheck.repository.OutboxEventRepository;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import java.time.Duration;
 import java.time.Instant;
 import org.springframework.stereotype.Service;
@@ -73,6 +74,11 @@ public class OutboxEventDispatcher {
       // Exponential Backoff 재시도 로직
       // TODO(PR#4): FirebaseMessagingException errorCode 기반 영구 실패 분류 도입
       // (예: UNREGISTERED, INVALID_ARGUMENT 등은 PENDING -> FAILED_PERMANENT 직행)
+      if (isPermanentFcmError(e)) {
+        event.markAsFailedPermanent();
+        outboxEventRepository.save(event);
+        return;
+      }
       // TODO(PR#5): FAILED_PERMANENT 전이 시 Notification.status(FAILED) 동기화 정책 확정 후 반영
       Duration backoff = Duration.ofSeconds(1L << event.getRetryCount()); // 1s, 2s, 4s
 
@@ -84,5 +90,11 @@ public class OutboxEventDispatcher {
         outboxEventRepository.save(event);
       }
     }
+  }
+
+  private boolean isPermanentFcmError(FirebaseMessagingException e) {
+    MessagingErrorCode errorCode = e.getMessagingErrorCode();
+    return errorCode == MessagingErrorCode.UNREGISTERED
+        || errorCode == MessagingErrorCode.INVALID_ARGUMENT;
   }
 }

--- a/src/test/java/com/beachcheck/integration/OutboxPublisherIntegrationTest.java
+++ b/src/test/java/com/beachcheck/integration/OutboxPublisherIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 import com.beachcheck.base.IntegrationTest;
@@ -23,6 +24,7 @@ import com.beachcheck.service.OutboxPublisher;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -327,6 +329,30 @@ class OutboxPublisherIntegrationTest extends IntegrationTest {
     assertThat(afterSecond.getStatus()).isEqualTo(OutboxEventStatus.FAILED_RETRIABLE);
     assertThat(afterSecond.getRetryCount()).isEqualTo(2);
     assertThat(afterSecond.getNextRetryAt()).isBetween(before.plusSeconds(2), after.plusSeconds(2));
+  }
+
+  @Test
+  @DisplayName("TC9 - UNREGISTERED 에러 코드 수신 시 retryCount=0에서도 즉시 FAILED_PERMANENT로 DB 저장")
+  void shouldPersistFailedPermanent_whenFcmReturnsUnregistered() throws FirebaseMessagingException {
+    // Given
+    Notification notification = createAndSaveNotification(NotificationStatus.PENDING);
+    OutboxEvent event = createAndSaveOutboxEvent(notification.getId());
+
+    FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+    given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
+    given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
+
+    // When
+    outboxPublisher.processPendingOutboxEvents();
+
+    // Then: Exponential Backoff 없이 즉시 영구 실패
+    OutboxEvent saved =
+        outboxEventRepository
+            .findById(event.getId())
+            .orElseThrow(() -> new IllegalStateException("OutboxEvent를 찾을 수 없습니다"));
+    assertThat(saved.getStatus()).isEqualTo(OutboxEventStatus.FAILED_PERMANENT);
+    assertThat(saved.getRetryCount()).isEqualTo(0);
+    assertThat(saved.getProcessedAt()).isNotNull();
   }
 
   // TODO: 향후 Dead Letter Queue 도입 시 별도 테이블 이관 여부 검증 필요

--- a/src/test/java/com/beachcheck/service/OutboxEventDispatcherTest.java
+++ b/src/test/java/com/beachcheck/service/OutboxEventDispatcherTest.java
@@ -19,6 +19,7 @@ import com.beachcheck.repository.OutboxEventRepository;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -187,6 +188,54 @@ class OutboxEventDispatcherTest {
       // Then: retryCount=2, nextRetryAt ≈ now + 2s (1<<1 = 2)
       assertThat(event.getRetryCount()).isEqualTo(2);
       assertThat(event.getNextRetryAt()).isBetween(before.plusSeconds(2), after.plusSeconds(2));
+    }
+
+    @Test
+    @DisplayName("TC7 - UNREGISTERED 에러 코드는 retryCount 무관 즉시 FAILED_PERMANENT")
+    void shouldMarkAsFailedPermanent_whenFcmErrorIsUnregistered()
+        throws FirebaseMessagingException {
+      // Given
+      UUID notificationId = UUID.randomUUID();
+      Notification notification = createNotification(notificationId, NotificationStatus.PENDING);
+      OutboxEvent event = createPendingEvent(notificationId); // retryCount = 0
+
+      FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+      given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
+      given(notificationRepository.findById(notificationId)).willReturn(Optional.of(notification));
+      given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
+
+      // When
+      dispatcher.dispatch(event);
+
+      // Then: retryCount=0인데도 FAILED_PERMANENT (backoff 없이 즉시 종료)
+      assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.FAILED_PERMANENT);
+      assertThat(event.getRetryCount()).isEqualTo(0);
+      assertThat(event.getProcessedAt()).isNotNull();
+      then(outboxEventRepository).should().save(event);
+    }
+
+    @Test
+    @DisplayName("TC8 - INVALID_ARGUMENT 에러 코드는 retryCount 무관 즉시 FAILED_PERMANENT")
+    void shouldMarkAsFailedPermanent_whenFcmErrorIsInvalidArgument()
+        throws FirebaseMessagingException {
+      // Given
+      UUID notificationId = UUID.randomUUID();
+      Notification notification = createNotification(notificationId, NotificationStatus.PENDING);
+      OutboxEvent event = createPendingEvent(notificationId); // retryCount = 0
+
+      FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+      given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.INVALID_ARGUMENT);
+      given(notificationRepository.findById(notificationId)).willReturn(Optional.of(notification));
+      given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
+
+      // When
+      dispatcher.dispatch(event);
+
+      // Then
+      assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.FAILED_PERMANENT);
+      assertThat(event.getRetryCount()).isEqualTo(0);
+      assertThat(event.getProcessedAt()).isNotNull();
+      then(outboxEventRepository).should().save(event);
     }
   }
 


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 이슈 링크 (필수)
- Jira: https://parkjaehong.atlassian.net/browse/PB-184
- GitHub: Related #184 (필수)
- GitHub: Closes # (Final PR만)

> PR 제목: `[feat] PB-88 (4/5) FCM 에러 코드 기반 영구 실패 분류 기능 구현`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #184의 4/5 단계
- 선행 PR: #XXX (머지 필요)
- 후속 PR: #XXX (블로킹)

### 이 PR에서 변경한 것
- `OutboxEventDispatcher`: `isPermanentFcmError()` 추가 — UNREGISTERED, INVALID_ARGUMENT 에러 코드는 retryCount 무관하게 즉시 FAILED_PERMANENT 전이
- 기존 Exponential Backoff 로직은 그 외 에러 코드(QUOTA_EXCEEDED, UNAVAILABLE 등)에만 유지
- 단위 테스트 2개, 통합 테스트 1개 추가

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
  - AC1: UNREGISTERED 에러 — FCM 토큰 만료 시 재시도 낭비 없이 즉시 FAILED_PERMANENT
  - AC2: INVALID_ARGUMENT 에러 — 잘못된 요청은 재시도해도 성공 불가, 즉시 FAILED_PERMANENT

  ### Not covered (후속 작업)
  - AC3: FAILED_PERMANENT 전이 시 Notification.status(FAILED) 동기화 — 운영 정책 논의 필요 → PR #XXX (PB-88 5/5)

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test
```
- ✅/❌ 결과: ✅

### CI
- (자동 첨부)

### Smoke 테스트
- 시나리오:
- 결과:

---

## 🧭 영향 범위 체크 (필수)
- [ ] API 변경 (요약: )
- [ ] DB 변경 (마이그레이션: )
- [ ] 설정 변경 (항목: )
- [ ] Breaking change (무엇: )

---

## 💬 리뷰 포인트 (필수)
  - 집중해서 볼 파일/라인: `OutboxEventDispatcher.java` — `isPermanentFcmError()` 메서드, catch 블록 분기 순서 (영구 실패 먼저 체크 후 Backoff fallback)
  - 트레이드오프/대안:
    - **분류 대상 에러 코드 범위**: UNREGISTERED, INVALID_ARGUMENT만 permanent로 지정. SENDER_ID_MISMATCH 등 추가 분류는 운영 관측 후 검토 예정
    - **null errorCode 처리**: `getMessagingErrorCode()` 반환값이 null이면 retriable로 간주 (방어적). 별도 null 체크 없이 `==` 비교로 처리
