### PR TITLE
[fix] PB-92 Flyway V2 체크섬 불일치 해결

### DIFF
--- a/src/main/resources/db/migration/V2__add_login.sql
+++ b/src/main/resources/db/migration/V2__add_login.sql
@@ -3,7 +3,6 @@ CREATE TABLE IF NOT EXISTS users (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     email VARCHAR UNIQUE NOT NULL,
     password VARCHAR NOT NULL,
-    -- TODO(OAuth): OAuth 계정은 password를 저장하지 않을 수 있으므로 nullable/더미값/별도 인증 테이블 정책 확정 후 스키마 반영.
     name VARCHAR(100) NOT NULL,
     role VARCHAR(20) NOT NULL DEFAULT 'USER',
     enabled BOOLEAN NOT NULL DEFAULT TRUE,
@@ -12,7 +11,6 @@ CREATE TABLE IF NOT EXISTS users (
     last_login_at TIMESTAMP WITH TIME ZONE,
     timezone VARCHAR,
     auth_provider VARCHAR(20),
-    -- TODO(OAuth): provider_user_id(예: Google sub/Kakao id) 컬럼 추가 및 (auth_provider, provider_user_id) UNIQUE 제약 도입.
     CONSTRAINT chk_role CHECK (role IN ('USER', 'ADMIN'))
     );
 


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 Jira Issue (필수)
- Key: **PB-92**
- Link: https://parkjaehong.atlassian.net/browse/PB-92

> PR 제목: `[fix] PB-92 Flyway V2 체크섬 불일치 해결`
> 브랜치: `fix/PB-92-flyway-v2-checksum-mismatch`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #197 

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 로컬에서 `.\gradlew.bat bootRun --stacktrace` 실행 시 Flyway validation 단계에서 `V2__add_login.sql` checksum mismatch가 발생해 애플리케이션이 기동되지 않음

### 왜 발생했나? (Root Cause)
- DB에는 과거 시점의 `V2__add_login.sql` checksum이 이미 저장되어 있었는데, 이후 동일 migration 파일에 TODO 주석이 추가되면서 로컬 파일 checksum이 달라짐
- Flyway는 주석 포함 파일 전체 텍스트 기준으로 checksum을 계산하므로, 사후 주석 변경도 validation 실패를 유발함

### 어떻게 고쳤나?
- `src/main/resources/db/migration/V2__add_login.sql`에서 사후 추가된 TODO 주석 2줄을 제거해 DB에 이미 적용된 migration 내용과 다시 일치시킴
- 이미 적용된 migration은 수정하지 않는 Flyway 원칙에 맞게 원복함

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  - 기존 Flyway 이력이 남아 있는 로컬 Postgres를 실행한다
  - `.\gradlew.bat bootRun --stacktrace`를 실행한다
- 기대 결과:
  - Flyway validation 통과 후 애플리케이션이 정상 기동한다
- 실제 결과:
  - `Migration checksum mismatch for migration version 2` 에러로 기동이 중단된다

### 재발 방지(있다면)
- [ ] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [x] 런북/문서 보강

---

##  Acceptance Criteria (AC) (필수)
- [x] AC1: `V2__add_login.sql` checksum mismatch가 발생하지 않아야 한다
- [x] AC2: `bootRun` 실행 시 Flyway validation이 정상 통과해야 한다
- [x] AC3: 이미 적용된 migration을 사후 수정한 상태가 아닌, DB 이력과 정합한 파일 상태여야 한다

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command:
  - `.\gradlew.bat bootRun --stacktrace`
- Result:
  - `Successfully validated 12 migrations`
  - `Schema "public" is up to date. No migration necessary.`
  - Flyway checksum mismatch는 재현되지 않음
  - 이후 애플리케이션은 별도 설정 이슈인 `app.mail.default-from이 설정되어야 합니다.`에서 중단됨

### CI
- 링크/결과: 미실행

### Smoke / 수동 검증
- 시나리오:
  - 로컬 DB(Postgres) 실행 상태에서 `bootRun` 재실행
  - Flyway validation 및 schema version 확인
- 결과:
  - Flyway 관련 blocker는 해소됨
  - 다음 차단점으로 메일 설정 누락이 드러남

### 테스트 공백(있다면 이유 필수)
- 이번 변경은 migration 파일 원복 성격이라 별도 자동화 테스트는 추가하지 않았음
- 전체 앱 정상 기동까지는 확인되지 않았고, Flyway 이후 단계에서 별도 설정 이슈(`app.mail.default-from`)가 남아 있음

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음  무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함  Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표:
  - 애플리케이션 기동 로그
  - Flyway migration validation 로그
- 에러/로그 키워드:
  - `Migration checksum mismatch`
  - `Successfully validated`
  - `flywayInitializer`

---

##  리스크 & 롤백 (필수)
### 리스크
- 다른 환경에서 이미 `flyway repair` 등으로 checksum을 별도로 맞춰둔 경우, 환경별 상태 차이가 있으면 추가 확인이 필요할 수 있음
- 현재 PR 범위는 Flyway mismatch 해소까지만 포함하며, 메일 설정 이슈는 별도 대응이 필요함

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 스크린샷/로그/메트릭 링크:
  - `Migration checksum mismatch for migration version 2`
  - `Applied to database : 1407047730`
  - `Resolved locally    : -1782010964`
  - 수정 후 `Successfully validated 12 migrations`
- 전/후 비교(가능하면):
  - 전: `V2__add_login.sql`에 사후 추가된 TODO 주석 포함
  - 후: DB에 적용된 상태와 동일하도록 TODO 주석 제거

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직:
  - `src/main/resources/db/migration/V2__add_login.sql`
- 트레이드오프/대안:
  - `flyway repair` 대신 migration 원복을 선택함
  - 이유는 이미 적용된 migration은 수정하지 않는 것이 Flyway 운영 원칙에 더 안전하기 때문
- 성능/보안/호환성 영향:
  - 성능 영향 없음
  - 보안 영향 없음
  - 호환성 측면에서 기존 DB 이력과의 정합성을 회복하는 변경임
