### PR TITLE
PB-109 Backend CD 이미지 빌드 단계 실패 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -70,8 +70,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          # latest는 현재 배포 기준점으로 쓰고, SHA 태그는 특정 이미지 추적과 롤백에 사용한다.
           tags: |
-            # latest는 현재 배포 기준점으로 쓰고, SHA 태그는 특정 이미지 추적과 롤백에 사용한다.
             ${{ steps.image-meta.outputs.image_repository }}:latest
             ${{ steps.image-meta.outputs.image_repository }}:${{ steps.image-meta.outputs.image_tag }}
 


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 Jira Issue (필수)
- Key: **PB-109**
- Link: https://parkjaehong.atlassian.net/browse/PB-109

> PR 제목: `PB-109 Backend CD 이미지 빌드 단계 실패 수정`  
> 브랜치: `fix/PB-109-backend-cd-build-push-failure`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #211

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- `main` 머지 후 실행된 `Backend CD` workflow가 Docker 이미지 빌드 단계에서 실패했다.

### 왜 발생했나? (Root Cause)
- `docker/build-push-action`의 `tags` 멀티라인 값 안에 주석이 포함되어, Docker가 주석 문자열을 잘못된 태그로 해석했다.

### 어떻게 고쳤나?
- `tags` 값 내부 주석을 제거하고, 설명 주석을 `tags` 필드 바깥으로 이동해 태그 문자열만 전달되도록 수정했다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. `backend-cd.yml` 이 포함된 변경을 `main`에 머지한다.
  2. `Backend CD` workflow 실행 결과를 확인한다.
- 기대 결과:
  - 이미지 빌드 및 push 후 EC2 배포 단계로 진행한다.
- 실제 결과:
  - `invalid tag "# latest는 현재 배포 기준점으로 쓰고": invalid reference format` 에러로 빌드 단계에서 실패했다.

### 재발 방지(있다면)
- [ ] 회귀 테스트 추가
- [x] 모니터링/알람 보강
- [x] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: `Backend CD` workflow의 이미지 빌드 단계가 잘못된 tag format 없이 실행된다.
- [x] AC2: `docker/build-push-action`에 `latest`와 `SHA` 태그가 정상 문자열로 전달된다.
- [x] AC3: 이미지 빌드 성공 시 이후 EC2 배포 job이 진행 가능해진다.


---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command:
  - `git diff -- .github/workflows/backend-cd.yml`
- Result:
  - `tags` 필드 내부 주석 제거 및 주석 위치 이동만 반영됨을 확인

### CI
- 링크/결과: PR 생성 후 확인 예정

### Smoke / 수동 검증
- 시나리오:
  - 실패한 GitHub Actions 로그와 수정된 workflow diff를 비교
- 결과:
  - 기존 실패 원인(`invalid tag`)이 제거되도록 수정

### 테스트 공백(있다면 이유 필수)
- GitHub Actions workflow는 로컬에서 동일 환경 재현이 어려워, 실제 검증은 PR 머지 또는 수동 실행 결과 확인이 필요함


---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 있음 (요약: GitHub Actions의 GHCR 이미지 빌드/푸시 흐름)
- [ ] 캐시/큐/외부 연동 영향 없음


---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:


---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표:
  - GitHub Actions `Backend CD` run status
- 에러/로그 키워드:
  - `invalid tag`
  - `Build and push backend image`


---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 실제 GHCR push 및 EC2 배포 검증은 workflow 재실행 결과를 확인해야 한다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )


---

## 📸 증빙 (선택)
- 스크린샷/로그/메트릭 링크:
  - 실패 run: https://github.com/Beach-complex/Beach_complex/actions/runs/24094672916
- 전/후 비교(가능하면):
  - 기존: `invalid tag "# latest는 현재 배포 기준점으로 쓰고"`
  - 수정 후: `tags` 값에 순수 이미지 태그만 전달

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직:
  - `.github/workflows/backend-cd.yml`
- 트레이드오프/대안:
  - 주석을 제거하는 대신 `tags` 외부 설명 주석으로 이동해 가독성을 유지했다.
- 성능/보안/호환성 영향:
  - 성능/보안 영향은 없고, CD workflow 호환성만 복구한다.
