### PR TITLE
[fix] PB-110 Backend CD 이미지 태그 파싱 실패 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -44,13 +44,11 @@ jobs:
         id: image-meta
         shell: bash
         run: |
-          # GHCR 이미지 이름은 소문자만 허용하므로 owner/repo 이름을 소문자로 정규화한다.
           owner_lower=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
           repo_name="${GITHUB_REPOSITORY#*/}"
           repo_lower=$(echo "${repo_name}" | tr '[:upper:]' '[:lower:]')
           image_repository="${REGISTRY}/${owner_lower}/${repo_lower}-backend"
 
-          # deploy job에서 재사용할 수 있도록 이미지 저장소명과 현재 커밋 SHA를 output으로 노출한다.
           echo "image_repository=${image_repository}" >> "${GITHUB_OUTPUT}"
           echo "image_tag=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
 
@@ -71,7 +69,6 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            # latest는 현재 배포 기준점으로 쓰고, SHA 태그는 특정 이미지 추적과 롤백에 사용한다.
             ${{ steps.image-meta.outputs.image_repository }}:latest
             ${{ steps.image-meta.outputs.image_repository }}:${{ steps.image-meta.outputs.image_tag }}
 
@@ -80,7 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     env:
-      # build job에서 계산한 이미지 정보를 deploy job 환경변수로 다시 주입해 원격 배포 스크립트에서 그대로 사용한다.
       IMAGE_REPOSITORY: ${{ needs.build-and-push.outputs.image_repository }}
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
       GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
@@ -104,10 +100,8 @@ jobs:
             cd "${EC2_DEPLOY_PATH}"
             echo "${GHCR_READ_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
 
-            # IMAGE_REPOSITORY와 IMAGE_TAG는 envs로 이미 전달되므로, compose가 참조하는 APP_RUNTIME_ENV_FILE만 재매핑한다.
             export APP_RUNTIME_ENV_FILE="${EC2_ENV_FILE}"
 
             docker compose -f "${EC2_COMPOSE_FILE}" pull app
             docker compose -f "${EC2_COMPOSE_FILE}" up -d app
-            # actuator는 애플리케이션 포트와 분리된 management 포트(8081)에서 헬스체크한다.
             curl --fail --silent --show-error http://127.0.0.1:8081/actuator/health


### PR DESCRIPTION
## 🔗 Jira Issue
- Key: **PB-110**
- Link: https://parkjaehong.atlassian.net/browse/PB-110

## 🔒 Close Issue
- Closes #213

## 🧩 요약
`Backend CD` workflow의 `docker/build-push-action` 설정에서 멀티라인 `tags` 입력 안에 주석이 섞여 있었다. GitHub Actions는 이 블록을 액션 입력 문자열로 전달하므로, 주석 라인이 실제 Docker tag로 해석되어 `invalid reference format` 오류가 발생했다. 그 결과 `Build and push backend image` 단계에서 매번 실패했고, 뒤따르는 EC2 배포 job이 실행되지 못했다.

이번 PR은 워크플로우에서 액션 입력값으로 오인될 수 있는 주석 라인을 제거해 `tags` 블록이 순수한 이미지 태그 값만 전달되도록 정리한다. 함께 같은 파일 안의 설명용 주석도 제거해 이후 유사한 파싱 혼선을 줄였다.

## ✅ 검증
- `git diff --check`
- 변경 범위가 `.github/workflows/backend-cd.yml` 한 파일인지 확인
- 기존 실패 로그와 동일한 원인인 `invalid tag` 경로를 워크플로우 정의에서 제거했는지 수동 점검

## ⚠️ 참고
실제 GitHub Actions 재실행 확인은 이 PR 머지 후 또는 수동 재실행이 필요하다.
