### PR TITLE
[chore] PB-116 로깅 표준 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     implementation 'org.springframework.retry:spring-retry'        // 스프링 재시도 라이브러리
     implementation 'org.springframework.boot:spring-boot-starter-aop'   // 스프링 AOP 스타터(의존성 명시를 위해 추가)
 
+    // 로깅 — prod 프로파일에서 NDJSON 출력
+    // 7.4: Logback 1.5.x(Spring Boot 3.3 동봉)와 호환되는 안정 버전
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+
     // AWS SDK v2 — Lambda Function URL SigV4 인증
     implementation platform('software.amazon.awssdk:bom:2.42.23')
     implementation 'software.amazon.awssdk:auth'

--- a/src/main/java/com/beachcheck/auth/dto/request/LogInRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/LogInRequestDto.java
@@ -6,4 +6,15 @@ import jakarta.validation.constraints.NotBlank;
 // TODO(OAuth): OAuth 로그인 요청 DTO 분리 또는 통합 시 구조 재정의.
 public record LogInRequestDto(
     @NotBlank(message = "Email is required") @Email(message = "Invaild email format") String email,
-    @NotBlank(message = "Password is required") String password) {}
+    @NotBlank(message = "Password is required") String password) {
+
+  /**
+   * Why: ADR-009 PII 마스킹 — record 기본 toString이 평문 password/email을 그대로 노출하는 것을 차단.
+   *
+   * <p>Contract(Output): 필드 값을 포함하지 않는 상수 문자열만 반환.
+   */
+  @Override
+  public String toString() {
+    return "LogInRequestDto[***masked***]";
+  }
+}

--- a/src/main/java/com/beachcheck/auth/dto/request/LogInRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/LogInRequestDto.java
@@ -1,5 +1,6 @@
 package com.beachcheck.auth.dto.request;
 
+import com.beachcheck.global.util.MaskingUtils;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
@@ -15,6 +16,6 @@ public record LogInRequestDto(
    */
   @Override
   public String toString() {
-    return "LogInRequestDto[***masked***]";
+    return MaskingUtils.maskedRecord(getClass().getSimpleName());
   }
 }

--- a/src/main/java/com/beachcheck/auth/dto/request/LogInRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/LogInRequestDto.java
@@ -9,7 +9,7 @@ public record LogInRequestDto(
     @NotBlank(message = "Password is required") String password) {
 
   /**
-   * Why: ADR-009 PII 마스킹 — record 기본 toString이 평문 password/email을 그대로 노출하는 것을 차단.
+   * Why: PII 마스킹 — record 기본 toString이 평문 password/email을 그대로 노출하는 것을 차단.
    *
    * <p>Contract(Output): 필드 값을 포함하지 않는 상수 문자열만 반환.
    */

--- a/src/main/java/com/beachcheck/auth/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/RefreshTokenRequestDto.java
@@ -3,4 +3,15 @@ package com.beachcheck.auth.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record RefreshTokenRequestDto(
-    @NotBlank(message = "Refresh token is required") String refreshToken) {}
+    @NotBlank(message = "Refresh token is required") String refreshToken) {
+
+  /**
+   * Why: ADR-009 PII 마스킹 — record 기본 toString이 raw refreshToken을 노출하는 것을 차단.
+   *
+   * <p>Contract(Output): 필드 값을 포함하지 않는 상수 문자열만 반환.
+   */
+  @Override
+  public String toString() {
+    return "RefreshTokenRequestDto[***masked***]";
+  }
+}

--- a/src/main/java/com/beachcheck/auth/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/RefreshTokenRequestDto.java
@@ -6,7 +6,7 @@ public record RefreshTokenRequestDto(
     @NotBlank(message = "Refresh token is required") String refreshToken) {
 
   /**
-   * Why: ADR-009 PII 마스킹 — record 기본 toString이 raw refreshToken을 노출하는 것을 차단.
+   * Why: PII 마스킹 — record 기본 toString이 raw refreshToken을 노출하는 것을 차단.
    *
    * <p>Contract(Output): 필드 값을 포함하지 않는 상수 문자열만 반환.
    */

--- a/src/main/java/com/beachcheck/auth/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/RefreshTokenRequestDto.java
@@ -1,5 +1,6 @@
 package com.beachcheck.auth.dto.request;
 
+import com.beachcheck.global.util.MaskingUtils;
 import jakarta.validation.constraints.NotBlank;
 
 public record RefreshTokenRequestDto(
@@ -12,6 +13,6 @@ public record RefreshTokenRequestDto(
    */
   @Override
   public String toString() {
-    return "RefreshTokenRequestDto[***masked***]";
+    return MaskingUtils.maskedRecord(getClass().getSimpleName());
   }
 }

--- a/src/main/java/com/beachcheck/auth/dto/request/ResendVerificationRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/ResendVerificationRequestDto.java
@@ -1,8 +1,20 @@
 package com.beachcheck.auth.dto.request;
 
+import com.beachcheck.global.util.MaskingUtils;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record ResendVerificationRequestDto(
     @NotBlank(message = "Email is required") @Email(message = "Invalid email format")
-        String email) {}
+        String email) {
+
+  /**
+   * Why: PII 마스킹 — record 기본 toString이 평문 email을 노출하는 것을 차단.
+   *
+   * <p>Contract(Output): 필드 값을 포함하지 않는 상수 문자열만 반환.
+   */
+  @Override
+  public String toString() {
+    return MaskingUtils.maskedRecord(getClass().getSimpleName());
+  }
+}

--- a/src/main/java/com/beachcheck/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/SignUpRequestDto.java
@@ -17,4 +17,15 @@ public record SignUpRequestDto(
         String password,
     @NotBlank(message = "Name is required")
         @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters")
-        String name) {}
+        String name) {
+
+  /**
+   * Why: ADR-009 PII 마스킹 — record 기본 toString이 평문 password/email/name을 노출하는 것을 차단.
+   *
+   * <p>Contract(Output): 필드 값을 포함하지 않는 상수 문자열만 반환.
+   */
+  @Override
+  public String toString() {
+    return "SignUpRequestDto[***masked***]";
+  }
+}

--- a/src/main/java/com/beachcheck/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/SignUpRequestDto.java
@@ -1,5 +1,6 @@
 package com.beachcheck.auth.dto.request;
 
+import com.beachcheck.global.util.MaskingUtils;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -26,6 +27,6 @@ public record SignUpRequestDto(
    */
   @Override
   public String toString() {
-    return "SignUpRequestDto[***masked***]";
+    return MaskingUtils.maskedRecord(getClass().getSimpleName());
   }
 }

--- a/src/main/java/com/beachcheck/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/request/SignUpRequestDto.java
@@ -20,7 +20,7 @@ public record SignUpRequestDto(
         String name) {
 
   /**
-   * Why: ADR-009 PII 마스킹 — record 기본 toString이 평문 password/email/name을 노출하는 것을 차단.
+   * Why: PII 마스킹 — record 기본 toString이 평문 password/email/name을 노출하는 것을 차단.
    *
    * <p>Contract(Output): 필드 값을 포함하지 않는 상수 문자열만 반환.
    */

--- a/src/main/java/com/beachcheck/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/AuthResponseDto.java
@@ -10,4 +10,21 @@ public record AuthResponseDto(
       String accessToken, String refreshToken, long expiresIn, UserResponseDto user) {
     return new AuthResponseDto(accessToken, refreshToken, "Bearer", expiresIn, user);
   }
+
+  /**
+   * Why: ADR-009 PII 마스킹 — record 기본 toString이 raw accessToken/refreshToken을 노출하는 것을 차단.
+   *
+   * <p>Contract(Output): 토큰 본문은 가리되 tokenType/expiresIn/user는 그대로 노출 (UserResponseDto는 PII가 제외된 응답
+   * 전용 DTO라는 전제).
+   */
+  @Override
+  public String toString() {
+    return "AuthResponseDto[accessToken=***masked***, refreshToken=***masked***, tokenType="
+        + tokenType
+        + ", expiresIn="
+        + expiresIn
+        + ", user="
+        + user
+        + "]";
+  }
 }

--- a/src/main/java/com/beachcheck/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/AuthResponseDto.java
@@ -1,5 +1,7 @@
 package com.beachcheck.auth.dto.response;
 
+import com.beachcheck.global.util.MaskingUtils;
+
 public record AuthResponseDto(
     String accessToken,
     String refreshToken,
@@ -19,7 +21,11 @@ public record AuthResponseDto(
    */
   @Override
   public String toString() {
-    return "AuthResponseDto[accessToken=***masked***, refreshToken=***masked***, tokenType="
+    return "AuthResponseDto["
+        + MaskingUtils.maskedField("accessToken")
+        + ", "
+        + MaskingUtils.maskedField("refreshToken")
+        + ", tokenType="
         + tokenType
         + ", expiresIn="
         + expiresIn

--- a/src/main/java/com/beachcheck/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/AuthResponseDto.java
@@ -12,7 +12,7 @@ public record AuthResponseDto(
   }
 
   /**
-   * Why: ADR-009 PII 마스킹 — record 기본 toString이 raw accessToken/refreshToken을 노출하는 것을 차단.
+   * Why: PII 마스킹 — record 기본 toString이 raw accessToken/refreshToken을 노출하는 것을 차단.
    *
    * <p>Contract(Output): 토큰 본문은 가리되 tokenType/expiresIn/user는 그대로 노출 (UserResponseDto는 PII가 제외된 응답
    * 전용 DTO라는 전제).

--- a/src/main/java/com/beachcheck/auth/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/TokenResponseDto.java
@@ -4,4 +4,18 @@ public record TokenResponseDto(String accessToken, String tokenType, long expire
   public static TokenResponseDto of(String accessToken, long expiresIn) {
     return new TokenResponseDto(accessToken, "Bearer", expiresIn);
   }
+
+  /**
+   * Why: ADR-009 PII 마스킹 — record 기본 toString이 raw accessToken을 노출하는 것을 차단.
+   *
+   * <p>Contract(Output): accessToken은 가리되 디버깅에 필요한 tokenType/expiresIn은 유지.
+   */
+  @Override
+  public String toString() {
+    return "TokenResponseDto[accessToken=***masked***, tokenType="
+        + tokenType
+        + ", expiresIn="
+        + expiresIn
+        + "]";
+  }
 }

--- a/src/main/java/com/beachcheck/auth/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/TokenResponseDto.java
@@ -6,7 +6,7 @@ public record TokenResponseDto(String accessToken, String tokenType, long expire
   }
 
   /**
-   * Why: ADR-009 PII 마스킹 — record 기본 toString이 raw accessToken을 노출하는 것을 차단.
+   * Why: PII 마스킹 — record 기본 toString이 raw accessToken을 노출하는 것을 차단.
    *
    * <p>Contract(Output): accessToken은 가리되 디버깅에 필요한 tokenType/expiresIn은 유지.
    */

--- a/src/main/java/com/beachcheck/auth/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/TokenResponseDto.java
@@ -1,5 +1,7 @@
 package com.beachcheck.auth.dto.response;
 
+import com.beachcheck.global.util.MaskingUtils;
+
 public record TokenResponseDto(String accessToken, String tokenType, long expiresIn) {
   public static TokenResponseDto of(String accessToken, long expiresIn) {
     return new TokenResponseDto(accessToken, "Bearer", expiresIn);
@@ -12,7 +14,9 @@ public record TokenResponseDto(String accessToken, String tokenType, long expire
    */
   @Override
   public String toString() {
-    return "TokenResponseDto[accessToken=***masked***, tokenType="
+    return "TokenResponseDto["
+        + MaskingUtils.maskedField("accessToken")
+        + ", tokenType="
         + tokenType
         + ", expiresIn="
         + expiresIn

--- a/src/main/java/com/beachcheck/auth/dto/response/UserResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/UserResponseDto.java
@@ -15,4 +15,22 @@ public record UserResponseDto(
         user.getCreatedAt(),
         user.getLastLoginAt());
   }
+
+  /**
+   * Why: ADR-009 PII 마스킹 — record 기본 toString이 email/name 평문을 노출하는 것을 차단.
+   *
+   * <p>Contract(Output): email/name은 가리되 추적에 유용한 id/role/createdAt/lastLoginAt은 유지.
+   */
+  @Override
+  public String toString() {
+    return "UserResponseDto[id="
+        + id
+        + ", email=***masked***, name=***masked***, role="
+        + role
+        + ", createdAt="
+        + createdAt
+        + ", lastLoginAt="
+        + lastLoginAt
+        + "]";
+  }
 }

--- a/src/main/java/com/beachcheck/auth/dto/response/UserResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/UserResponseDto.java
@@ -17,7 +17,7 @@ public record UserResponseDto(
   }
 
   /**
-   * Why: ADR-009 PII 마스킹 — record 기본 toString이 email/name 평문을 노출하는 것을 차단.
+   * Why: PII 마스킹 — record 기본 toString이 email/name 평문을 노출하는 것을 차단.
    *
    * <p>Contract(Output): email/name은 가리되 추적에 유용한 id/role/createdAt/lastLoginAt은 유지.
    */

--- a/src/main/java/com/beachcheck/auth/dto/response/UserResponseDto.java
+++ b/src/main/java/com/beachcheck/auth/dto/response/UserResponseDto.java
@@ -1,5 +1,6 @@
 package com.beachcheck.auth.dto.response;
 
+import com.beachcheck.global.util.MaskingUtils;
 import com.beachcheck.user.domain.User;
 import java.time.Instant;
 import java.util.UUID;
@@ -25,7 +26,11 @@ public record UserResponseDto(
   public String toString() {
     return "UserResponseDto[id="
         + id
-        + ", email=***masked***, name=***masked***, role="
+        + ", "
+        + MaskingUtils.maskedField("email")
+        + ", "
+        + MaskingUtils.maskedField("name")
+        + ", role="
         + role
         + ", createdAt="
         + createdAt

--- a/src/main/java/com/beachcheck/global/logging/MdcRequestFilter.java
+++ b/src/main/java/com/beachcheck/global/logging/MdcRequestFilter.java
@@ -1,0 +1,62 @@
+package com.beachcheck.global.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Why: ADR-009 로깅 표준 — 요청 단위 상관관계 ID(requestId)를 MDC에 주입해, 로그 한 줄만 보고도 동일 요청 흐름을 추적할 수 있게 한다.
+ *
+ * <p>Policy:
+ *
+ * <ul>
+ *   <li>외부에서 {@code X-Request-Id} 헤더를 보내면 그대로 사용(게이트웨이/LB와 ID 통합)
+ *   <li>없으면 UUID로 생성
+ *   <li>응답 헤더에 동일 ID를 실어 클라이언트가 장애 신고 시 본인 요청 ID를 알 수 있게 함
+ *   <li>{@code finally}에서 반드시 MDC 정리 — 스레드풀 재사용 시 다음 요청에 누수 방지
+ * </ul>
+ *
+ * <p>Contract(Input): 임의의 HTTP 요청. {@code X-Request-Id} 헤더는 선택.
+ *
+ * <p>Contract(Output): 응답 헤더 {@code X-Request-Id} 항상 세팅. MDC 키 {@code requestId} 가 요청 처리 도중에만 유효하고,
+ * 요청 종료 후에는 반드시 제거됨.
+ *
+ * <p>TODO: traceId/spanId는 트레이싱 SDK(ADR-011)가 자동 주입할 예정이므로 본 필터에서는 다루지 않는다. userId는 인증 직후 {@link
+ * com.beachcheck.global.security.JwtAuthenticationFilter}에서 주입한다.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MdcRequestFilter extends OncePerRequestFilter {
+
+  private static final String MDC_REQUEST_ID = "requestId";
+  private static final String HEADER_REQUEST_ID = "X-Request-Id";
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+
+    String requestId = request.getHeader(HEADER_REQUEST_ID);
+    if (!StringUtils.hasText(requestId)) {
+      requestId = UUID.randomUUID().toString();
+    }
+
+    MDC.put(MDC_REQUEST_ID, requestId);
+    response.setHeader(HEADER_REQUEST_ID, requestId);
+
+    try {
+      chain.doFilter(request, response);
+    } finally {
+      MDC.remove(MDC_REQUEST_ID);
+    }
+  }
+}

--- a/src/main/java/com/beachcheck/global/logging/MdcRequestFilter.java
+++ b/src/main/java/com/beachcheck/global/logging/MdcRequestFilter.java
@@ -14,7 +14,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * Why: ADR-009 로깅 표준 — 요청 단위 상관관계 ID(requestId)를 MDC에 주입해, 로그 한 줄만 보고도 동일 요청 흐름을 추적할 수 있게 한다.
+ * Why: 로깅 표준 — 요청 단위 상관관계 ID(requestId)를 MDC에 주입해, 로그 한 줄만 보고도 동일 요청 흐름을 추적할 수 있게 한다.
  *
  * <p>Policy:
  *
@@ -30,7 +30,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * <p>Contract(Output): 응답 헤더 {@code X-Request-Id} 항상 세팅. MDC 키 {@code requestId} 가 요청 처리 도중에만 유효하고,
  * 요청 종료 후에는 반드시 제거됨.
  *
- * <p>TODO: traceId/spanId는 트레이싱 SDK(ADR-011)가 자동 주입할 예정이므로 본 필터에서는 다루지 않는다. userId는 인증 직후 {@link
+ * <p>TODO: traceId/spanId는 트레이싱 SDK가 자동 주입할 예정이므로 본 필터에서는 다루지 않는다. userId는 인증 직후 {@link
  * com.beachcheck.global.security.JwtAuthenticationFilter}에서 주입한다.
  */
 @Component

--- a/src/main/java/com/beachcheck/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/beachcheck/global/security/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
+import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -34,10 +35,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     return p != null && p.startsWith("/api/_debug/");
   }
 
+  /**
+   * Why: ADR-009 로깅 표준 — 인증 성공 시 {@code userId}를 MDC에 주입해, 이후 로그 라인에 사용자 식별자가 따라붙도록 한다. 스레드풀 재사용
+   * 환경에서 누수가 일어나지 않도록 try-finally로 정리한다.
+   *
+   * <p>Policy:
+   *
+   * <ul>
+   *   <li>JWT 검증 실패/사용자 미존재 등 인증 실패 시 MDC에 아무것도 넣지 않음 (이전 요청 잔재도 없음)
+   *   <li>인증 성공 시점에만 {@code userIdPushed=true}로 표시하고, finally에서 해당 키만 제거
+   *   <li>예외 흐름이 기존과 달라지지 않도록 catch 분기에서도 동일한 finally를 거치게 함
+   * </ul>
+   */
   @Override
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
+    boolean userIdPushed = false;
     try {
       String jwt = getJwtFromRequest(request);
 
@@ -47,7 +61,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UserDetails userDetails =
             userRepository
                 .findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
 
         UsernamePasswordAuthenticationToken authentication =
             new UsernamePasswordAuthenticationToken(
@@ -55,12 +69,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        MDC.put("userId", userId.toString());
+        userIdPushed = true;
       }
     } catch (Exception ex) {
-      logger.error("Could not set user authentication in security context", ex);
+
+      logger.error("보안 컨텍스트에 사용자 인증을 설정할 수 없습니다.", ex);
     }
 
-    filterChain.doFilter(request, response);
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      if (userIdPushed) {
+        MDC.remove("userId");
+      }
+    }
   }
 
   private String getJwtFromRequest(HttpServletRequest request) {

--- a/src/main/java/com/beachcheck/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/beachcheck/global/security/JwtAuthenticationFilter.java
@@ -36,8 +36,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   /**
-   * Why: ADR-009 로깅 표준 — 인증 성공 시 {@code userId}를 MDC에 주입해, 이후 로그 라인에 사용자 식별자가 따라붙도록 한다. 스레드풀 재사용
-   * 환경에서 누수가 일어나지 않도록 try-finally로 정리한다.
+   * Why: 로깅 표준 — 인증 성공 시 {@code userId}를 MDC에 주입해, 이후 로그 라인에 사용자 식별자가 따라붙도록 한다. 스레드풀 재사용 환경에서 누수가
+   * 일어나지 않도록 try-finally로 정리한다.
    *
    * <p>Policy:
    *

--- a/src/main/java/com/beachcheck/global/util/MaskingUtils.java
+++ b/src/main/java/com/beachcheck/global/util/MaskingUtils.java
@@ -1,0 +1,28 @@
+package com.beachcheck.global.util;
+
+/**
+ * Why: DTO toString 경로에서 민감 값과 값의 구조가 로그에 노출되지 않도록 공통 마스킹 표현을 제공한다.
+ *
+ * <p>Policy:
+ *
+ * <ul>
+ *   <li>전체 마스킹은 필드 값과 필드 구조를 숨긴다.
+ *   <li>부분 마스킹은 필드명만 남기고 값을 고정 마스킹 값으로 대체한다.
+ * </ul>
+ *
+ * <p>Contract(Output): 모든 마스킹 값은 {@link #MASKED_VALUE}를 사용한다.
+ */
+public final class MaskingUtils {
+
+  public static final String MASKED_VALUE = "****";
+
+  private MaskingUtils() {}
+
+  public static String maskedRecord(String typeName) {
+    return typeName + "[" + MASKED_VALUE + "]";
+  }
+
+  public static String maskedField(String fieldName) {
+    return fieldName + "=" + MASKED_VALUE;
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+# dev 프로파일 — 로컬 개발용 (ADR-009)
+# 활성화 방법:
+#   SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
+#   또는 ./gradlew bootRun --args='--spring.profiles.active=dev'
+#
+# 로깅 정책은 src/main/resources/logback-spring.xml 의 <springProfile name="dev | local | default"> 블록 참조.
+# 본 파일은 골격만 유지하고, dev 전용 오버라이드가 필요해질 때 키를 추가한다.
+spring:
+  config:
+    activate:
+      on-profile: dev

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,4 @@
-# dev 프로파일 — 로컬 개발용 (ADR-009)
+# dev 프로파일 — 로컬 개발용
 # 활성화 방법:
 #   SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
 #   또는 ./gradlew bootRun --args='--spring.profiles.active=dev'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+# prod 프로파일 — 운영 배포용 (ADR-009)
+# 활성화 방법:
+#   SPRING_PROFILES_ACTIVE=prod (백엔드 CD에서 환경변수 주입)
+#
+# 로깅 정책은 src/main/resources/logback-spring.xml 의 <springProfile name="prod"> 블록 참조.
+# - NDJSON 한 줄 출력
+# - com.beachcheck=INFO, Hibernate SQL/bind=OFF
+# - 스택트레이스 30프레임 / 4096자 제한
+#
+# 본 파일은 골격만 유지하고, prod 전용 오버라이드가 필요해질 때 키를 추가한다.
+spring:
+  config:
+    activate:
+      on-profile: prod

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,4 @@
-# prod 프로파일 — 운영 배포용 (ADR-009)
+# prod 프로파일 — 운영 배포용
 # 활성화 방법:
 #   SPRING_PROFILES_ACTIVE=prod (백엔드 CD에서 환경변수 주입)
 #

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,15 +67,9 @@ management:
     mail:
       enabled: true  # 운영 환경에서 메일 서버 상태 확인 활성화
 
-logging:
-  level:
-    org.springframework.security: INFO
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE
-    com.beachcheck: DEBUG
-    org.springframework.web.client: DEBUG
-    
-
+# 로깅 레벨/포맷은 logback-spring.xml로 일원화 (ADR-009)
+# - dev/local/default: 평문, com.beachcheck=DEBUG, Hibernate SQL/bind 노출
+# - prod: NDJSON, com.beachcheck=INFO, Hibernate SQL/bind=OFF
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,7 +67,7 @@ management:
     mail:
       enabled: true  # 운영 환경에서 메일 서버 상태 확인 활성화
 
-# 로깅 레벨/포맷은 logback-spring.xml로 일원화 (ADR-009)
+# 로깅 레벨/포맷은 logback-spring.xml로 일원화
 # - dev/local/default: 평문, com.beachcheck=DEBUG, Hibernate SQL/bind 노출
 # - prod: NDJSON, com.beachcheck=INFO, Hibernate SQL/bind=OFF
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ADR-009: 로깅 표준
+  - dev/local/default: 사람이 읽기 좋은 평문
+  - prod: NDJSON (logstash-logback-encoder)
+  - MDC 키 노출: traceId, spanId, userId, requestId
+-->
+<configuration>
+
+    <!-- 공통: MDC 키 노출 목록 (참조용) -->
+    <property name="MDC_KEYS" value="traceId,spanId,userId,requestId"/>
+
+    <!-- ─────────── dev / local / default: 평문 ─────────── -->
+    <springProfile name="dev | local | default">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%X{traceId:-},%X{userId:-}] %logger{36} - %msg%n
+                </pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <logger name="com.beachcheck" level="DEBUG"/>
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.hibernate.orm.jdbc.bind" level="TRACE"/>
+        <logger name="org.springframework.security" level="INFO"/>
+        <logger name="org.springframework.web.client" level="DEBUG"/>
+    </springProfile>
+
+    <!-- ─────────── prod: NDJSON ─────────── -->
+    <springProfile name="prod">
+        <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+                <includeMdcKeyName>spanId</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>requestId</includeMdcKeyName>
+                <fieldNames>
+                    <timestamp>@timestamp</timestamp>
+                    <thread>thread</thread>
+                    <logger>logger</logger>
+                    <levelValue>[ignore]</levelValue>
+                </fieldNames>
+                <!-- 스택트레이스 길이 제한 (운영 비용 절감) -->
+                <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                    <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                    <maxLength>4096</maxLength>
+                    <rootCauseFirst>true</rootCauseFirst>
+                </throwableConverter>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="STDOUT_JSON"/>
+        </root>
+
+        <logger name="com.beachcheck" level="INFO"/>
+        <logger name="org.hibernate.SQL" level="OFF"/>
+        <logger name="org.hibernate.orm.jdbc.bind" level="OFF"/>
+        <logger name="org.springframework.security" level="WARN"/>
+        <logger name="org.springframework.web.client" level="INFO"/>
+    </springProfile>
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   로깅 표준
-  - dev/local/default: 사람이 읽기 좋은 평문
+  - dev/local/test/default: 사람이 읽기 좋은 평문
   - prod: NDJSON (logstash-logback-encoder)
   - MDC 키 노출: traceId, spanId, userId, requestId
 -->
@@ -10,12 +10,12 @@
     <!-- 공통: MDC 키 노출 목록 (참조용) -->
     <property name="MDC_KEYS" value="traceId,spanId,userId,requestId"/>
 
-    <!-- ─────────── dev / local / default: 평문 ─────────── -->
-    <springProfile name="dev | local | default">
+    <!-- ─────────── dev / local / test / default: 평문 ─────────── -->
+    <springProfile name="dev | local | test | default">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
                 <pattern>
-                    %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%X{traceId:-},%X{userId:-}] %logger{36} - %msg%n
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [traceId=%X{traceId:-},requestId=%X{requestId:-},userId=%X{userId:-}] %logger{36} - %msg%n
                 </pattern>
             </encoder>
         </appender>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ADR-009: 로깅 표준
+  로깅 표준
   - dev/local/default: 사람이 읽기 좋은 평문
   - prod: NDJSON (logstash-logback-encoder)
   - MDC 키 노출: traceId, spanId, userId, requestId

--- a/src/test/java/com/beachcheck/auth/dto/DtoToStringMaskingTest.java
+++ b/src/test/java/com/beachcheck/auth/dto/DtoToStringMaskingTest.java
@@ -1,0 +1,135 @@
+package com.beachcheck.auth.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.beachcheck.auth.dto.request.LogInRequestDto;
+import com.beachcheck.auth.dto.request.RefreshTokenRequestDto;
+import com.beachcheck.auth.dto.request.SignUpRequestDto;
+import com.beachcheck.auth.dto.response.AuthResponseDto;
+import com.beachcheck.auth.dto.response.TokenResponseDto;
+import com.beachcheck.auth.dto.response.UserResponseDto;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("인증 record DTO toString PII 마스킹 — ADR-009")
+class DtoToStringMaskingTest {
+
+  // 테스트 더미 자격증명 — toString 결과에 이 값들이 노출되지 않는지 검증하는 데 쓴다.
+  // TODO: 두 번째 테스트가 동일 더미 자격증명을 필요로 하면 support/fixture/AuthTestFixtures로 추출한다.
+  private static final String SAMPLE_EMAIL = "victim@example.com";
+  private static final String SAMPLE_PASSWORD = "Password1!"; // gitleaks:allow 테스트 픽스처(실제 비밀번호 아님)
+  private static final String SAMPLE_NAME = "홍길동VictimName";
+  private static final String SAMPLE_ACCESS_TOKEN = "sample-access-token-value";
+  private static final String SAMPLE_REFRESH_TOKEN = "sample-refresh-token-value";
+
+  @Nested
+  @DisplayName("Request DTO — 전체 마스킹")
+  class RequestDtos {
+
+    @Test
+    @DisplayName("LogInRequestDto.toString은 email/password를 노출하지 않는다")
+    void logInRequest_doesNotLeakCredentials() {
+      // given
+      LogInRequestDto dto = new LogInRequestDto(SAMPLE_EMAIL, SAMPLE_PASSWORD);
+
+      // when
+      String result = dto.toString();
+
+      // then
+      assertThat(result).doesNotContain(SAMPLE_EMAIL).doesNotContain(SAMPLE_PASSWORD);
+      assertThat(result).contains("LogInRequestDto").contains("masked");
+    }
+
+    @Test
+    @DisplayName("SignUpRequestDto.toString은 email/password/name을 노출하지 않는다")
+    void signUpRequest_doesNotLeakCredentials() {
+      // given
+      SignUpRequestDto dto = new SignUpRequestDto(SAMPLE_EMAIL, SAMPLE_PASSWORD, SAMPLE_NAME);
+
+      // when
+      String result = dto.toString();
+
+      // then
+      assertThat(result)
+          .doesNotContain(SAMPLE_EMAIL)
+          .doesNotContain(SAMPLE_PASSWORD)
+          .doesNotContain(SAMPLE_NAME);
+      assertThat(result).contains("SignUpRequestDto").contains("masked");
+    }
+
+    @Test
+    @DisplayName("RefreshTokenRequestDto.toString은 refreshToken 본문을 노출하지 않는다")
+    void refreshTokenRequest_doesNotLeakToken() {
+      // given
+      RefreshTokenRequestDto dto = new RefreshTokenRequestDto(SAMPLE_REFRESH_TOKEN);
+
+      // when
+      String result = dto.toString();
+
+      // then
+      assertThat(result).doesNotContain(SAMPLE_REFRESH_TOKEN);
+      assertThat(result).contains("RefreshTokenRequestDto").contains("masked");
+    }
+  }
+
+  @Nested
+  @DisplayName("Response DTO — 부분 마스킹 (민감 필드만)")
+  class ResponseDtos {
+
+    @Test
+    @DisplayName("TokenResponseDto.toString은 accessToken은 가리고 tokenType/expiresIn은 노출한다")
+    void tokenResponse_masksAccessTokenButKeepsMetadata() {
+      // given
+      TokenResponseDto dto = TokenResponseDto.of(SAMPLE_ACCESS_TOKEN, 3600L);
+
+      // when
+      String result = dto.toString();
+
+      // then
+      assertThat(result).doesNotContain(SAMPLE_ACCESS_TOKEN);
+      assertThat(result).contains("Bearer").contains("3600");
+    }
+
+    @Test
+    @DisplayName("UserResponseDto.toString은 email/name은 가리고 id/role은 노출한다")
+    void userResponse_masksEmailAndNameButKeepsId() {
+      // given
+      UUID id = UUID.randomUUID();
+      UserResponseDto dto =
+          new UserResponseDto(id, SAMPLE_EMAIL, SAMPLE_NAME, "USER", Instant.now(), Instant.now());
+
+      // when
+      String result = dto.toString();
+
+      // then
+      assertThat(result).doesNotContain(SAMPLE_EMAIL).doesNotContain(SAMPLE_NAME);
+      assertThat(result).contains(id.toString()).contains("USER");
+    }
+
+    @Test
+    @DisplayName(
+        "AuthResponseDto.toString은 accessToken/refreshToken을 가리고, user 필드 체이닝으로도 email/name이 새지 않는다")
+    void authResponse_masksAllTokensAndPropagatesUserMasking() {
+      // given
+      UserResponseDto user =
+          new UserResponseDto(
+              UUID.randomUUID(), SAMPLE_EMAIL, SAMPLE_NAME, "USER", Instant.now(), Instant.now());
+      AuthResponseDto dto =
+          AuthResponseDto.of(SAMPLE_ACCESS_TOKEN, SAMPLE_REFRESH_TOKEN, 3600L, user);
+
+      // when
+      String result = dto.toString();
+
+      // then
+      assertThat(result)
+          .doesNotContain(SAMPLE_ACCESS_TOKEN)
+          .doesNotContain(SAMPLE_REFRESH_TOKEN)
+          .doesNotContain(SAMPLE_EMAIL)
+          .doesNotContain(SAMPLE_NAME);
+      assertThat(result).contains("Bearer").contains("3600");
+    }
+  }
+}

--- a/src/test/java/com/beachcheck/auth/dto/DtoToStringMaskingTest.java
+++ b/src/test/java/com/beachcheck/auth/dto/DtoToStringMaskingTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.beachcheck.auth.dto.request.LogInRequestDto;
 import com.beachcheck.auth.dto.request.RefreshTokenRequestDto;
+import com.beachcheck.auth.dto.request.ResendVerificationRequestDto;
 import com.beachcheck.auth.dto.request.SignUpRequestDto;
 import com.beachcheck.auth.dto.response.AuthResponseDto;
 import com.beachcheck.auth.dto.response.TokenResponseDto;
@@ -40,7 +41,7 @@ class DtoToStringMaskingTest {
 
       // then
       assertThat(result).doesNotContain(SAMPLE_EMAIL).doesNotContain(SAMPLE_PASSWORD);
-      assertThat(result).contains("LogInRequestDto").contains("masked");
+      assertThat(result).contains("LogInRequestDto").contains("****");
     }
 
     @Test
@@ -57,7 +58,7 @@ class DtoToStringMaskingTest {
           .doesNotContain(SAMPLE_EMAIL)
           .doesNotContain(SAMPLE_PASSWORD)
           .doesNotContain(SAMPLE_NAME);
-      assertThat(result).contains("SignUpRequestDto").contains("masked");
+      assertThat(result).contains("SignUpRequestDto").contains("****");
     }
 
     @Test
@@ -71,7 +72,21 @@ class DtoToStringMaskingTest {
 
       // then
       assertThat(result).doesNotContain(SAMPLE_REFRESH_TOKEN);
-      assertThat(result).contains("RefreshTokenRequestDto").contains("masked");
+      assertThat(result).contains("RefreshTokenRequestDto").contains("****");
+    }
+
+    @Test
+    @DisplayName("ResendVerificationRequestDto.toString은 email을 노출하지 않는다")
+    void resendVerificationRequest_doesNotLeakEmail() {
+      // given
+      ResendVerificationRequestDto dto = new ResendVerificationRequestDto(SAMPLE_EMAIL);
+
+      // when
+      String result = dto.toString();
+
+      // then
+      assertThat(result).doesNotContain(SAMPLE_EMAIL);
+      assertThat(result).contains("ResendVerificationRequestDto").contains("****");
     }
   }
 

--- a/src/test/java/com/beachcheck/auth/dto/DtoToStringMaskingTest.java
+++ b/src/test/java/com/beachcheck/auth/dto/DtoToStringMaskingTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("인증 record DTO toString PII 마스킹 — ADR-009")
+@DisplayName("인증 record DTO toString PII 마스킹")
 class DtoToStringMaskingTest {
 
   // 테스트 더미 자격증명 — toString 결과에 이 값들이 노출되지 않는지 검증하는 데 쓴다.

--- a/src/test/java/com/beachcheck/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/beachcheck/auth/service/AuthServiceTest.java
@@ -393,7 +393,7 @@ class AuthServiceTest {
     return new RefreshTokenBuilder();
   }
 
-  private static class UserBuilder {
+  private static final class UserBuilder {
     private UUID id = UUID.randomUUID();
     private String email = EMAIL;
     private String password = RAW_PASS;
@@ -428,7 +428,7 @@ class AuthServiceTest {
     }
   }
 
-  private static class RefreshTokenBuilder {
+  private static final class RefreshTokenBuilder {
     private UUID id = UUID.randomUUID();
     private User user;
     private String tokenValue = REFRESH_TOKEN;

--- a/src/test/java/com/beachcheck/global/logging/DtoLoggingCatalogTest.java
+++ b/src/test/java/com/beachcheck/global/logging/DtoLoggingCatalogTest.java
@@ -1,0 +1,221 @@
+package com.beachcheck.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.beachcheck.auth.dto.request.LogInRequestDto;
+import com.beachcheck.auth.dto.request.RefreshTokenRequestDto;
+import com.beachcheck.auth.dto.request.ResendVerificationRequestDto;
+import com.beachcheck.auth.dto.request.SignUpRequestDto;
+import com.beachcheck.auth.dto.response.AuthResponseDto;
+import com.beachcheck.auth.dto.response.TokenResponseDto;
+import com.beachcheck.auth.dto.response.UserResponseDto;
+import com.beachcheck.beach.dto.BeachConditionDto;
+import com.beachcheck.beach.dto.BeachDto;
+import com.beachcheck.beach.dto.BeachFacilityDto;
+import com.beachcheck.beach.dto.request.BeachSearchRequestDto;
+import com.beachcheck.external.congestion.CongestionCurrentResponse;
+import com.beachcheck.global.exception.ApiErrorResponse;
+import com.beachcheck.notification.domain.Notification.NotificationStatus;
+import com.beachcheck.notification.domain.Notification.NotificationType;
+import com.beachcheck.notification.dto.NotificationResponseDto;
+import com.beachcheck.notification.dto.NotificationSendRequestDto;
+import com.beachcheck.reservation.dto.ReservationCreateRequest;
+import com.beachcheck.reservation.dto.ReservationResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.boot.logging.LoggingInitializationContext;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.mock.env.MockEnvironment;
+
+@DisplayName("DTO 로깅 출력 카탈로그")
+@ExtendWith(OutputCaptureExtension.class)
+class DtoLoggingCatalogTest {
+
+  private static final Logger log = LoggerFactory.getLogger(DtoLoggingCatalogTest.class);
+
+  private static final String SAMPLE_EMAIL = "victim@example.com";
+  private static final String SAMPLE_PASSWORD = "Password1!"; // gitleaks:allow 테스트 픽스처(실제 비밀번호 아님)
+  private static final String SAMPLE_ACCESS_TOKEN = "sample-access-token-value";
+  private static final String SAMPLE_REFRESH_TOKEN = "sample-refresh-token-value";
+  private static final Instant SAMPLE_TIME = Instant.parse("2026-06-08T00:00:00Z");
+  private static final UUID SAMPLE_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final UUID SAMPLE_BEACH_ID =
+      UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+  private LoggingSystem loggingSystem;
+
+  @AfterEach
+  void cleanUp() {
+    MDC.clear();
+    if (loggingSystem != null) {
+      loggingSystem.cleanUp();
+    }
+  }
+
+  @Test
+  @DisplayName("dev 프로파일 DTO 로그 샘플을 평문 파일로 남긴다")
+  void devProfile_writesPlainTextDtoCatalog(CapturedOutput output) throws IOException {
+    // given
+    initializeLogging("dev");
+
+    // when
+    logDtoCatalog();
+
+    // then
+    writeReport("dto-catalog-dev.log", output);
+    assertThat(output)
+        .contains("[trace-catalog,user-catalog]")
+        .contains("LogInRequestDto[****]")
+        .contains("BeachSearchRequestDto")
+        .doesNotContain(SAMPLE_EMAIL)
+        .doesNotContain(SAMPLE_PASSWORD)
+        .doesNotContain(SAMPLE_ACCESS_TOKEN)
+        .doesNotContain(SAMPLE_REFRESH_TOKEN)
+        .doesNotContain("\"@timestamp\"");
+  }
+
+  @Test
+  @DisplayName("prod 프로파일 DTO 로그 샘플을 JSONL 파일로 남긴다")
+  void prodProfile_writesJsonDtoCatalog(CapturedOutput output) throws IOException {
+    // given
+    initializeLogging("prod");
+
+    // when
+    logDtoCatalog();
+
+    // then
+    writeReport("dto-catalog-prod.jsonl", output);
+    assertThat(output)
+        .contains("\"@timestamp\"")
+        .contains("\"traceId\":\"trace-catalog\"")
+        .contains("\"spanId\":\"span-catalog\"")
+        .contains("\"userId\":\"user-catalog\"")
+        .contains("\"requestId\":\"request-catalog\"")
+        .contains("LogInRequestDto[****]")
+        .contains("BeachSearchRequestDto")
+        .doesNotContain(SAMPLE_EMAIL)
+        .doesNotContain(SAMPLE_PASSWORD)
+        .doesNotContain(SAMPLE_ACCESS_TOKEN)
+        .doesNotContain(SAMPLE_REFRESH_TOKEN);
+  }
+
+  private void initializeLogging(String profile) {
+    loggingSystem = LoggingSystem.get(getClass().getClassLoader());
+    loggingSystem.cleanUp();
+    loggingSystem.beforeInitialize();
+
+    MockEnvironment environment = new MockEnvironment();
+    environment.setActiveProfiles(profile);
+    loggingSystem.initialize(
+        new LoggingInitializationContext(environment), "classpath:logback-spring.xml", null);
+  }
+
+  private void logDtoCatalog() {
+    putCatalogMdc();
+    for (Map.Entry<String, Object> dto : sampleDtos()) {
+      log.info("dtoName={}, dto={}", dto.getKey(), dto.getValue());
+    }
+  }
+
+  private void putCatalogMdc() {
+    MDC.put("traceId", "trace-catalog");
+    MDC.put("spanId", "span-catalog");
+    MDC.put("userId", "user-catalog");
+    MDC.put("requestId", "request-catalog");
+  }
+
+  private List<Map.Entry<String, Object>> sampleDtos() {
+    UserResponseDto user =
+        new UserResponseDto(SAMPLE_ID, SAMPLE_EMAIL, "홍길동VictimName", "USER", SAMPLE_TIME, null);
+    TokenResponseDto token = TokenResponseDto.of(SAMPLE_ACCESS_TOKEN, 3600L);
+
+    return List.of(
+        Map.entry("LogInRequestDto", new LogInRequestDto(SAMPLE_EMAIL, SAMPLE_PASSWORD)),
+        Map.entry("SignUpRequestDto", new SignUpRequestDto(SAMPLE_EMAIL, SAMPLE_PASSWORD, "홍길동")),
+        Map.entry("RefreshTokenRequestDto", new RefreshTokenRequestDto(SAMPLE_REFRESH_TOKEN)),
+        Map.entry("ResendVerificationRequestDto", new ResendVerificationRequestDto(SAMPLE_EMAIL)),
+        Map.entry("UserResponseDto", user),
+        Map.entry("TokenResponseDto", token),
+        Map.entry(
+            "AuthResponseDto",
+            AuthResponseDto.of(SAMPLE_ACCESS_TOKEN, SAMPLE_REFRESH_TOKEN, 3600L, user)),
+        Map.entry(
+            "BeachDto",
+            new BeachDto(
+                SAMPLE_BEACH_ID,
+                "BUSAN_HAEUNDAE",
+                "해운대해수욕장",
+                "OPEN",
+                35.1587,
+                129.1604,
+                SAMPLE_TIME,
+                "family",
+                true)),
+        Map.entry(
+            "BeachConditionDto",
+            new BeachConditionDto(
+                SAMPLE_ID, SAMPLE_BEACH_ID, SAMPLE_TIME, 22.5, 0.7, "맑음", 35.1587, 129.1604)),
+        Map.entry(
+            "BeachFacilityDto",
+            new BeachFacilityDto(SAMPLE_ID, SAMPLE_BEACH_ID, "샤워장", "SHOWER", 35.1588, 129.1605)),
+        Map.entry(
+            "BeachSearchRequestDto",
+            new BeachSearchRequestDto("해운대", "family", 35.1587, 129.1604, 3.0)),
+        Map.entry(
+            "ReservationCreateRequest",
+            new ReservationCreateRequest("2026-06-08T00:00:00Z", "event-123")),
+        Map.entry(
+            "ReservationResponse",
+            new ReservationResponse(
+                SAMPLE_ID, "CONFIRMED", SAMPLE_TIME, SAMPLE_BEACH_ID, "event-123", SAMPLE_TIME)),
+        Map.entry(
+            "NotificationSendRequestDto",
+            new NotificationSendRequestDto(
+                SAMPLE_ID, NotificationType.TEST, "테스트 알림", "스모크 테스트 메시지")),
+        Map.entry(
+            "NotificationResponseDto",
+            new NotificationResponseDto(
+                SAMPLE_ID,
+                NotificationType.TEST,
+                "테스트 알림",
+                "스모크 테스트 메시지",
+                NotificationStatus.SENT,
+                SAMPLE_TIME,
+                SAMPLE_TIME)),
+        Map.entry(
+            "ApiErrorResponse",
+            new ApiErrorResponse("BAD_REQUEST", "요청 값이 올바르지 않습니다.", Map.of("field", "email"))),
+        Map.entry("CongestionCurrentResponse", congestionResponse()));
+  }
+
+  private CongestionCurrentResponse congestionResponse() {
+    return new CongestionCurrentResponse(
+        "BUSAN_HAEUNDAE",
+        "해운대해수욕장",
+        new CongestionCurrentResponse.InputContext(
+            SAMPLE_TIME, new CongestionCurrentResponse.WeatherInput(24.1, 0.0, 3.2), false),
+        new CongestionCurrentResponse.OutputBlock(0.42, 42.0, "NORMAL", "rule-v1"),
+        new CongestionCurrentResponse.OutputBlock(0.51, 51.0, "BUSY", "ai-v1"));
+  }
+
+  private void writeReport(String fileName, CapturedOutput output) throws IOException {
+    Path reportPath = Path.of("build", "reports", "logging-smoke", fileName);
+    Files.createDirectories(reportPath.getParent());
+    Files.writeString(reportPath, output.toString(), StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/com/beachcheck/global/logging/DtoLoggingCatalogTest.java
+++ b/src/test/java/com/beachcheck/global/logging/DtoLoggingCatalogTest.java
@@ -79,7 +79,9 @@ class DtoLoggingCatalogTest {
     // then
     writeReport("dto-catalog-dev.log", output);
     assertThat(output)
-        .contains("[trace-catalog,user-catalog]")
+        .contains("traceId=trace-catalog")
+        .contains("requestId=request-catalog")
+        .contains("userId=user-catalog")
         .contains("LogInRequestDto[****]")
         .contains("BeachSearchRequestDto")
         .doesNotContain(SAMPLE_EMAIL)

--- a/src/test/java/com/beachcheck/global/logging/MdcRequestFilterTest.java
+++ b/src/test/java/com/beachcheck/global/logging/MdcRequestFilterTest.java
@@ -1,0 +1,135 @@
+package com.beachcheck.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@DisplayName("MdcRequestFilter 단위 테스트 — ADR-009 requestId MDC 주입/정리")
+class MdcRequestFilterTest {
+
+  private static final String MDC_KEY = "requestId";
+  private static final String HEADER = "X-Request-Id";
+
+  private final MdcRequestFilter filter = new MdcRequestFilter();
+
+  @AfterEach
+  void clearMdc() {
+    MDC.clear();
+  }
+
+  @Nested
+  @DisplayName("정상 흐름")
+  class HappyPath {
+
+    @Test
+    @DisplayName("요청에 X-Request-Id 헤더가 있으면 그 값을 그대로 MDC와 응답 헤더에 사용한다")
+    void givenIncomingHeader_whenFilter_thenReuseProvidedId() throws Exception {
+      // given
+      String incoming = "req-from-gateway-12345";
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader(HEADER, incoming);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      CapturingFilterChain chain = new CapturingFilterChain();
+
+      // when
+      filter.doFilter(request, response, chain);
+
+      // then
+      assertThat(chain.capturedRequestId).isEqualTo(incoming);
+      assertThat(response.getHeader(HEADER)).isEqualTo(incoming);
+    }
+
+    @Test
+    @DisplayName("X-Request-Id 헤더가 없으면 UUID를 생성해 MDC와 응답 헤더에 동일 ID를 박는다")
+    void givenNoHeader_whenFilter_thenGenerateUuidAndEcho() throws Exception {
+      // given
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      CapturingFilterChain chain = new CapturingFilterChain();
+
+      // when
+      filter.doFilter(request, response, chain);
+
+      // then — UUID는 36자, 응답 헤더와 동일
+      assertThat(chain.capturedRequestId).isNotBlank().hasSize(36);
+      assertThat(response.getHeader(HEADER)).isEqualTo(chain.capturedRequestId);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 헤더는 빈 값으로 신뢰하지 않고 UUID로 생성한다")
+    void givenBlankHeader_whenFilter_thenGenerateUuid() throws Exception {
+      // given
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader(HEADER, "   ");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      CapturingFilterChain chain = new CapturingFilterChain();
+
+      // when
+      filter.doFilter(request, response, chain);
+
+      // then
+      assertThat(chain.capturedRequestId).isNotBlank().hasSize(36);
+    }
+  }
+
+  @Nested
+  @DisplayName("MDC 누수 방지")
+  class MdcCleanup {
+
+    @Test
+    @DisplayName("필터 통과 후 MDC에서 requestId가 제거된다 (스레드풀 재사용 누수 방지)")
+    void afterFilter_mdcIsCleared() throws Exception {
+      // given
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      // when
+      filter.doFilter(request, response, new MockFilterChain());
+
+      // then
+      assertThat(MDC.get(MDC_KEY)).isNull();
+    }
+
+    @Test
+    @DisplayName("체인 실행 중 예외가 발생해도 MDC가 정리된다 (try-finally 보장)")
+    void exceptionInChain_mdcStillCleared() {
+      // given
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      FilterChain blowingChain =
+          (req, res) -> {
+            throw new RuntimeException("boom");
+          };
+
+      // when
+      Throwable thrown = catchThrowable(() -> filter.doFilter(request, response, blowingChain));
+
+      // then
+      assertThat(thrown).isInstanceOf(RuntimeException.class).hasMessage("boom");
+      assertThat(MDC.get(MDC_KEY)).isNull();
+    }
+  }
+
+  /** 체인 실행 시점의 MDC 값을 캡처해, 필터가 doFilter 호출 전에 MDC를 박았는지 검증한다. */
+  private static final class CapturingFilterChain implements FilterChain {
+    String capturedRequestId;
+
+    @Override
+    public void doFilter(
+        jakarta.servlet.ServletRequest request, jakarta.servlet.ServletResponse response)
+        throws IOException, ServletException {
+      capturedRequestId = MDC.get(MDC_KEY);
+    }
+  }
+}

--- a/src/test/java/com/beachcheck/global/logging/MdcRequestFilterTest.java
+++ b/src/test/java/com/beachcheck/global/logging/MdcRequestFilterTest.java
@@ -15,7 +15,7 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-@DisplayName("MdcRequestFilter 단위 테스트 — ADR-009 requestId MDC 주입/정리")
+@DisplayName("MdcRequestFilter 단위 테스트 — requestId MDC 주입/정리")
 class MdcRequestFilterTest {
 
   private static final String MDC_KEY = "requestId";

--- a/src/test/java/com/beachcheck/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/beachcheck/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,200 @@
+package com.beachcheck.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.beachcheck.support.fixture.UserTestFixtures;
+import com.beachcheck.user.domain.User;
+import com.beachcheck.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtAuthenticationFilter 단위 테스트 — ADR-009 userId MDC 주입/정리")
+class JwtAuthenticationFilterTest {
+
+  private static final String VALID_JWT = "valid.jwt.token";
+  private static final String MDC_KEY = "userId";
+
+  @Mock private JwtUtils jwtUtils;
+  @Mock private UserRepository userRepository;
+
+  private JwtAuthenticationFilter filter;
+
+  @AfterEach
+  void tearDown() {
+    MDC.clear();
+    SecurityContextHolder.clearContext();
+  }
+
+  private void newFilter() {
+    filter = new JwtAuthenticationFilter(jwtUtils, userRepository);
+  }
+
+  @Nested
+  @DisplayName("인증 성공")
+  class AuthenticationSucceeds {
+
+    @Test
+    @DisplayName("정상 JWT 인증 시 체인 실행 도중에는 MDC userId가 채워지고, 종료 후엔 제거된다")
+    void givenValidJwt_whenFilter_thenMdcSetDuringChainAndClearedAfter() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = UserTestFixtures.createUser("jwt-mdc@example.com");
+      user.setId(userId);
+
+      given(jwtUtils.validateToken(VALID_JWT)).willReturn(true);
+      given(jwtUtils.isAccessToken(VALID_JWT)).willReturn(true);
+      given(jwtUtils.getUserIdFromToken(VALID_JWT)).willReturn(userId);
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      newFilter();
+
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer " + VALID_JWT);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      MdcSnapshotChain chain = new MdcSnapshotChain();
+
+      // when
+      filter.doFilter(request, response, chain);
+
+      // then
+      assertThat(chain.userIdDuringChain).isEqualTo(userId.toString());
+      assertThat(MDC.get(MDC_KEY)).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("인증 미수행 / 실패 시 MDC 무변경")
+  class NoAuthentication {
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 MDC에 userId가 박히지 않고 종료 후에도 비어있다")
+    void givenNoAuthorizationHeader_whenFilter_thenMdcUntouched() throws Exception {
+      // given
+      newFilter();
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      MdcSnapshotChain chain = new MdcSnapshotChain();
+
+      // when
+      filter.doFilter(request, response, chain);
+
+      // then
+      assertThat(chain.userIdDuringChain).isNull();
+      assertThat(MDC.get(MDC_KEY)).isNull();
+      verify(userRepository, never()).findById(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("JWT 검증이 실패하면 MDC에 userId가 박히지 않고, 체인은 계속 진행된다")
+    void givenInvalidJwt_whenFilter_thenMdcUntouchedAndChainProceeds() throws Exception {
+      // given
+      given(jwtUtils.validateToken(VALID_JWT)).willReturn(false);
+      newFilter();
+
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer " + VALID_JWT);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      MdcSnapshotChain chain = new MdcSnapshotChain();
+
+      // when
+      filter.doFilter(request, response, chain);
+
+      // then
+      assertThat(chain.invoked).isTrue();
+      assertThat(chain.userIdDuringChain).isNull();
+      assertThat(MDC.get(MDC_KEY)).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("외부 컴포넌트가 미리 박아둔 MDC 보존")
+  class PreExistingMdc {
+
+    @Test
+    @DisplayName("필터 진입 전에 외부에서 박아둔 userId는 인증 실패 케이스에서 지워지지 않는다 (userIdPushed 가드 검증)")
+    void preExistingUserId_isNotErasedOnAuthFailure() throws Exception {
+      // given
+      String externallyPushed = "external-user-id";
+      MDC.put(MDC_KEY, externallyPushed);
+      newFilter();
+
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      // Authorization 헤더 없음 → 인증 시도 안 함
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      // when
+      filter.doFilter(request, response, new MockFilterChain());
+
+      // then — 우리 필터는 박지 않았으므로 지우지도 않음
+      assertThat(MDC.get(MDC_KEY)).isEqualTo(externallyPushed);
+    }
+  }
+
+  @Nested
+  @DisplayName("MDC 누수 방지")
+  class MdcCleanup {
+
+    @Test
+    @DisplayName("체인 실행 중 예외가 발생해도 인증으로 박힌 MDC userId는 finally에서 제거된다")
+    void exceptionInChain_mdcStillCleared() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = UserTestFixtures.createUser("cleanup@example.com");
+      user.setId(userId);
+
+      given(jwtUtils.validateToken(VALID_JWT)).willReturn(true);
+      given(jwtUtils.isAccessToken(VALID_JWT)).willReturn(true);
+      given(jwtUtils.getUserIdFromToken(VALID_JWT)).willReturn(userId);
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      newFilter();
+
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer " + VALID_JWT);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      FilterChain blowingChain =
+          (req, res) -> {
+            throw new RuntimeException("controller exploded");
+          };
+
+      // when
+      Throwable thrown = catchThrowable(() -> filter.doFilter(request, response, blowingChain));
+
+      // then
+      assertThat(thrown).isInstanceOf(RuntimeException.class).hasMessage("controller exploded");
+      assertThat(MDC.get(MDC_KEY)).isNull();
+    }
+  }
+
+  /** 체인 실행 시점의 MDC userId 값과 호출 여부를 캡처. */
+  private static final class MdcSnapshotChain implements FilterChain {
+    boolean invoked;
+    String userIdDuringChain;
+
+    @Override
+    public void doFilter(
+        jakarta.servlet.ServletRequest request, jakarta.servlet.ServletResponse response)
+        throws IOException, ServletException {
+      invoked = true;
+      userIdDuringChain = MDC.get(MDC_KEY);
+    }
+  }
+}

--- a/src/test/java/com/beachcheck/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/beachcheck/global/security/JwtAuthenticationFilterTest.java
@@ -28,7 +28,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("JwtAuthenticationFilter 단위 테스트 — ADR-009 userId MDC 주입/정리")
+@DisplayName("JwtAuthenticationFilter 단위 테스트 — userId MDC 주입/정리")
 class JwtAuthenticationFilterTest {
 
   private static final String VALID_JWT = "valid.jwt.token";


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 Jira Issue (필수)
- Key: **PB-116**
- Link: https://parkjaehong.atlassian.net/browse/PB-116

> PR 제목: `[chore] PB-116 로깅 표준 적용`  
> 브랜치: `chore/PB-116-logging-standard`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #226 

---

## 🧩 한눈에 요약 (필수)
  ### 무엇을 변경했나?
  - [ ] 인프라
  - [x] 설정파일 (logback-spring.xml, application-{dev,prod}.yml)
  - [x] 빌드 파일 (build.gradle 의존성)
  - [ ] CI
  - [x] 의존성
  - [x] 런타임 코드 변경 있음 — MDC 주입 필터 신규, 인증 필터 수정,
        인증 DTO toString PII 마스킹 (ADR-0XX)

  ### 왜 필요한가?
  - 외부 로깅 저장소 도입을 위해 prod 프로파일 로그를 NDJSON으로 직렬화하고,
    요청/사용자 단위 추적이 가능하도록 MDC(requestId·userId) 표준을 적용 (ADR-0XX)
  - 인증 DTO의 record 기본 toString이 password·token·email 평문을 로그에
    노출하던 문제를 toString 오버라이드로 차단 (PII 마스킹)

  ### 범위(스코프)
  - Included: logback-spring.xml 프로파일별 로깅 정책, dev/prod yml 골격,
    MdcRequestFilter 신규, JwtAuthenticationFilter userId MDC 주입,
    인증 DTO 6종 toString 마스킹, logstash-logback-encoder 의존성
  - Not included: 외부 호출 헤더 전파, traceId/spanId 자동 주입(ADR-0XX 트레이싱 SDK 예정)

  ## 🧪 테스트 / 검증 (필수)
  ### 로컬
  - Command: `./gradlew test --tests "com.beachcheck.global.logging.*" \
    --tests "com.beachcheck.global.security.JwtAuthenticationFilterTest" \
    --tests "com.beachcheck.auth.dto.DtoToStringMaskingTest"`
  - Result: <성공/실패 + 통과 개수 기재>

  ### 테스트 공백
  - 없음 — 신규 필터·DTO 마스킹 단위 테스트 470줄 추가 (정상/예외/MDC 누수 케이스 포함)

  ## 🧭 영향 범위 (필수)
  - [x] 설정/환경변수 변경 있음 (항목: SPRING_PROFILES_ACTIVE — dev/prod 프로파일 분기,
        미지정 시 default 프로파일로 평문 로깅)
  - [x] CI/빌드 파이프라인 영향 없음
  - [x] 의존성 변경 있음 (net.logstash.logback:logstash-logback-encoder:7.4 신규 추가)

  ## ⚠️ 리스크 & 롤백 (필수)
  ### 리스크
  - prod 배포 시 SPRING_PROFILES_ACTIVE=prod 미주입 시 default 프로파일로 떨어져
    평문 로그가 출력될 수 있음 (CD 환경변수 확인 필요)
  - 기존 application.yml의 logging.level 블록 제거 → 로깅 정책이 logback-spring.xml로
    완전 이관됨. prod에서 com.beachcheck=INFO, Hibernate SQL/bind=OFF로 레벨 변동

  ### 롤백
  - [x] 단순 revert로 가능

  ## 💬 리뷰 가이드 (필수)
  - 꼭 봐야 하는 파일: logback-spring.xml(프로파일별 정책),
    JwtAuthenticationFilter(try-finally MDC 정리), AuthResponseDto/UserResponseDto(부분 마스킹)
  - 트레이드오프: Response DTO는 전체 마스킹 대신 id/role/expiresIn 등 비민감 필드는
    디버깅 편의를 위해 노출 유지
  - 보안 영향: 인증 DTO toString의 평문 PII 노출 차단이 본 PR의 핵심 보안 변경