### PR TITLE
[Feat] PB-119 @Async 경계 MDC(requestId/userId) 전파

### DIFF
--- a/src/main/java/com/beachcheck/global/config/AsyncConfig.java
+++ b/src/main/java/com/beachcheck/global/config/AsyncConfig.java
@@ -19,10 +19,10 @@ public class AsyncConfig {
    * <p>Policy:
    *
    * <ul>
-   *   <li>Core Pool Size: 5 (기본 유지 스레드 개수, 항상 살아있음)
-   *   <li>Max Pool Size: 10 (최대 스레드 개수, 부하 시 5→10까지 증가)
-   *   <li>Queue Capacity: 100 (대기 큐 크기, 스레드 풀이 가득 찰 때 대기)
-   *   <li>Thread Name Prefix: "notification-" (로그 추적 용이성)
+   *   <li>Core Pool Size: 3 (기본 유지 스레드 개수, 항상 살아있음)
+   *   <li>Max Pool Size: 6 (최대 스레드 개수, 부하 시 3→6까지 증가)
+   *   <li>Queue Capacity: 50 (대기 큐 크기, 스레드 풀이 가득 찰 때 대기)
+   *   <li>Thread Name Prefix: "email-" (로그 추적 용이성)
    *   <li>Task Decorator: MdcTaskDecorator (부모 요청 스레드의 MDC를 worker thread로 전파)
    * </ul>
    *

--- a/src/main/java/com/beachcheck/global/config/AsyncConfig.java
+++ b/src/main/java/com/beachcheck/global/config/AsyncConfig.java
@@ -1,5 +1,6 @@
 package com.beachcheck.global.config;
 
+import com.beachcheck.global.logging.MdcTaskDecorator;
 import java.util.concurrent.Executor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +23,7 @@ public class AsyncConfig {
    *   <li>Max Pool Size: 10 (최대 스레드 개수, 부하 시 5→10까지 증가)
    *   <li>Queue Capacity: 100 (대기 큐 크기, 스레드 풀이 가득 찰 때 대기)
    *   <li>Thread Name Prefix: "notification-" (로그 추적 용이성)
+   *   <li>Task Decorator: MdcTaskDecorator (부모 요청 스레드의 MDC를 worker thread로 전파)
    * </ul>
    *
    * <p>Contract(Output): TaskExecutor 인스턴스 반환
@@ -35,6 +37,7 @@ public class AsyncConfig {
     executor.setMaxPoolSize(6);
     executor.setQueueCapacity(50);
     executor.setThreadNamePrefix("email-");
+    executor.setTaskDecorator(new MdcTaskDecorator());
     executor.initialize();
     return executor;
   }

--- a/src/main/java/com/beachcheck/global/logging/MdcTaskDecorator.java
+++ b/src/main/java/com/beachcheck/global/logging/MdcTaskDecorator.java
@@ -1,0 +1,53 @@
+package com.beachcheck.global.logging;
+
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+/**
+ * Why: {@code @Async} 경계에서 MDC가 끊기는 문제 해결 — MDC는 ThreadLocal 기반이라 작업이 worker thread로 넘어가면 부모 요청
+ * 스레드의 {@code requestId}/{@code userId}가 사라진다. 작업 제출 시점의 MDC를 worker thread로 복사해, 비동기 작업 로그도 동일
+ * 요청으로 추적할 수 있게 한다.
+ *
+ * <p>Policy:
+ *
+ * <ul>
+ *   <li>작업 제출 시점(부모 스레드)의 MDC를 복사해 worker thread 실행 직전 주입
+ *   <li>부모 MDC가 비어 있으면 worker thread MDC를 {@code clear} (이전 작업 컨텍스트 누수 차단)
+ *   <li>실행 후 {@code finally}에서 worker thread의 원래 MDC를 복원 — 스레드풀 재사용 시 다음 작업에 누수 방지
+ *   <li>새 로그 키는 만들지 않는다. MDC1에서 정한 표준 키만 그대로 전파한다.
+ * </ul>
+ *
+ * <p>Contract(Input): 비동기로 제출되는 임의의 {@link Runnable}.
+ *
+ * <p>Contract(Output): 부모 MDC가 적용된 상태로 실행되는 {@link Runnable}. 실행 종료(정상/예외 무관) 후 worker thread MDC는
+ * 실행 직전 상태로 복원됨.
+ *
+ * <p>TODO: executor가 늘어나면 모든 애플리케이션 executor에 동일 데코레이터를 적용한다. traceId/spanId는 트레이싱 SDK가 자동 주입할
+ * 예정이므로 본 데코레이터에서 다루지 않는다.
+ */
+public class MdcTaskDecorator implements TaskDecorator {
+
+  @Override
+  public Runnable decorate(Runnable runnable) {
+    Map<String, String> callerContext = MDC.getCopyOfContextMap();
+
+    return () -> {
+      Map<String, String> previousContext = MDC.getCopyOfContextMap();
+      try {
+        if (callerContext == null || callerContext.isEmpty()) {
+          MDC.clear();
+        } else {
+          MDC.setContextMap(callerContext);
+        }
+        runnable.run();
+      } finally {
+        if (previousContext == null || previousContext.isEmpty()) {
+          MDC.clear();
+        } else {
+          MDC.setContextMap(previousContext);
+        }
+      }
+    };
+  }
+}

--- a/src/test/java/com/beachcheck/global/config/AsyncConfigTest.java
+++ b/src/test/java/com/beachcheck/global/config/AsyncConfigTest.java
@@ -1,0 +1,65 @@
+package com.beachcheck.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@DisplayName("AsyncConfig 통합 테스트 — emailTaskExecutor MDC 전파 설정 검증")
+class AsyncConfigTest {
+
+  private static final String REQUEST_ID = "requestId";
+  private static final String USER_ID = "userId";
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner().withUserConfiguration(AsyncConfig.class);
+
+  @AfterEach
+  void clearMdc() {
+    MDC.clear();
+  }
+
+  @Test
+  @DisplayName(
+      "emailTaskExecutor로 제출한 작업이 부모 스레드의 requestId/userId를 worker thread에서 읽고, 제출 스레드 MDC는 유지된다")
+  void givenCallerMdc_whenSubmittedToExecutor_thenPropagatedToWorkerAndCallerPreserved() {
+    contextRunner.run(
+        context -> {
+          // given — 실제 등록된 emailTaskExecutor 빈을 꺼내고 제출 스레드에 MDC를 세팅
+          ThreadPoolTaskExecutor executor =
+              context.getBean("emailTaskExecutor", ThreadPoolTaskExecutor.class);
+          MDC.put(REQUEST_ID, "req-async");
+          MDC.put(USER_ID, "user-async");
+
+          AtomicReference<String> requestIdInWorker = new AtomicReference<>();
+          AtomicReference<String> userIdInWorker = new AtomicReference<>();
+          AtomicReference<String> workerThreadName = new AtomicReference<>();
+
+          // when — executor로 작업을 제출하고 완료를 기다린다
+          Future<?> future =
+              executor.submit(
+                  () -> {
+                    requestIdInWorker.set(MDC.get(REQUEST_ID));
+                    userIdInWorker.set(MDC.get(USER_ID));
+                    workerThreadName.set(Thread.currentThread().getName());
+                  });
+          future.get(2, TimeUnit.SECONDS);
+
+          // then — 별도 worker thread에서 실행되었고 부모 MDC가 전파됨
+          assertThat(workerThreadName.get()).startsWith("email-");
+          assertThat(requestIdInWorker.get()).isEqualTo("req-async");
+          assertThat(userIdInWorker.get()).isEqualTo("user-async");
+
+          // then — 제출 스레드의 MDC는 작업 제출/완료 후에도 그대로 유지됨
+          assertThat(MDC.get(REQUEST_ID)).isEqualTo("req-async");
+          assertThat(MDC.get(USER_ID)).isEqualTo("user-async");
+        });
+  }
+}

--- a/src/test/java/com/beachcheck/global/logging/MdcTaskDecoratorTest.java
+++ b/src/test/java/com/beachcheck/global/logging/MdcTaskDecoratorTest.java
@@ -1,0 +1,115 @@
+package com.beachcheck.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+@DisplayName("MdcTaskDecorator 단위 테스트 — @Async 경계 MDC 전파/정리")
+class MdcTaskDecoratorTest {
+
+  private static final String REQUEST_ID = "requestId";
+  private static final String USER_ID = "userId";
+
+  private final MdcTaskDecorator decorator = new MdcTaskDecorator();
+
+  @AfterEach
+  void clearMdc() {
+    // MDC는 ThreadLocal이므로 테스트 간 누수가 생기면 원인 추적이 어렵다.
+    MDC.clear();
+  }
+
+  @Nested
+  @DisplayName("부모 MDC 전파")
+  class Propagation {
+
+    @Test
+    @DisplayName("부모 스레드 MDC를 작업 실행 중 worker thread로 복사하고 종료 후 정리한다")
+    void givenCallerMdc_whenRun_thenVisibleDuringRunAndClearedAfter() {
+      // given — 부모(제출 시점) MDC 세팅
+      MDC.put(REQUEST_ID, "req-1");
+      MDC.put(USER_ID, "user-1");
+      AtomicReference<String> requestIdDuringRun = new AtomicReference<>();
+      AtomicReference<String> userIdDuringRun = new AtomicReference<>();
+      Runnable decorated =
+          decorator.decorate(
+              () -> {
+                requestIdDuringRun.set(MDC.get(REQUEST_ID));
+                userIdDuringRun.set(MDC.get(USER_ID));
+              });
+
+      // when — worker thread가 비어 있는 상태를 모사 후 실행
+      MDC.clear();
+      decorated.run();
+
+      // then — 실행 중에는 부모 값이 보이고, 실행 후에는 정리됨
+      assertThat(requestIdDuringRun.get()).isEqualTo("req-1");
+      assertThat(userIdDuringRun.get()).isEqualTo("user-1");
+      assertThat(MDC.get(REQUEST_ID)).isNull();
+      assertThat(MDC.get(USER_ID)).isNull();
+    }
+
+    @Test
+    @DisplayName("부모 MDC가 비어 있으면 worker thread의 기존 값을 비우고 실행한다 (이전 작업 누수 차단)")
+    void givenEmptyCallerMdc_whenRun_thenWorkerMdcClearedDuringRun() {
+      // given — 부모 MDC가 빈 상태에서 데코레이트
+      MDC.clear();
+      AtomicReference<String> requestIdDuringRun = new AtomicReference<>();
+      Runnable decorated = decorator.decorate(() -> requestIdDuringRun.set(MDC.get(REQUEST_ID)));
+
+      // when — worker thread에 이전 작업의 값이 남아 있는 상태를 모사 후 실행
+      MDC.put(REQUEST_ID, "leftover-from-previous-task");
+      decorated.run();
+
+      // then — 실행 중에는 부모(빈 값)가 적용되어 이전 값이 보이지 않음
+      assertThat(requestIdDuringRun.get()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("worker thread MDC 복원/정리")
+  class Restoration {
+
+    @Test
+    @DisplayName("worker thread에 기존 MDC가 있으면 실행 후 그 값으로 복원한다")
+    void givenWorkerHadMdc_whenRun_thenRestoredAfter() {
+      // given — 부모 값으로 데코레이트
+      MDC.put(REQUEST_ID, "caller-req");
+      AtomicReference<String> requestIdDuringRun = new AtomicReference<>();
+      Runnable decorated = decorator.decorate(() -> requestIdDuringRun.set(MDC.get(REQUEST_ID)));
+
+      // when — worker thread가 자체 값을 가진 상태를 모사 후 실행
+      MDC.put(REQUEST_ID, "worker-existing");
+      decorated.run();
+
+      // then — 실행 중에는 부모 값, 실행 후에는 worker 원래 값으로 복원
+      assertThat(requestIdDuringRun.get()).isEqualTo("caller-req");
+      assertThat(MDC.get(REQUEST_ID)).isEqualTo("worker-existing");
+    }
+
+    @Test
+    @DisplayName("runnable이 예외를 던져도 worker thread MDC를 정리한다 (try-finally 보장)")
+    void givenRunnableThrows_whenRun_thenMdcStillCleared() {
+      // given — 부모 값 세팅 후 예외를 던지는 작업
+      MDC.put(REQUEST_ID, "req-1");
+      Runnable decorated =
+          decorator.decorate(
+              () -> {
+                throw new RuntimeException("boom");
+              });
+
+      // when — worker thread가 비어 있는 상태를 모사 후 실행
+      MDC.clear();
+      Throwable thrown = catchThrowable(decorated::run);
+
+      // then — 예외는 그대로 전파되고 MDC는 정리됨
+      assertThat(thrown).isInstanceOf(RuntimeException.class).hasMessage("boom");
+      assertThat(MDC.get(REQUEST_ID)).isNull();
+    }
+  }
+}

--- a/src/test/java/com/beachcheck/global/logging/integration/AsyncConfigIntegrationTest.java
+++ b/src/test/java/com/beachcheck/global/logging/integration/AsyncConfigIntegrationTest.java
@@ -99,6 +99,7 @@ class AsyncConfigIntegrationTest {
     }
   }
 
+  // 호출 클래스와 클래스를 분리하여 실제 @Async 프록시가 적용된 상태로 테스트
   static class AsyncProbe {
 
     @Async("emailTaskExecutor")

--- a/src/test/java/com/beachcheck/global/logging/integration/AsyncConfigIntegrationTest.java
+++ b/src/test/java/com/beachcheck/global/logging/integration/AsyncConfigIntegrationTest.java
@@ -1,7 +1,8 @@
-package com.beachcheck.global.config;
+package com.beachcheck.global.logging.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.beachcheck.global.config.AsyncConfig;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -13,7 +14,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @DisplayName("AsyncConfig 통합 테스트 — emailTaskExecutor MDC 전파 설정 검증")
-class AsyncConfigTest {
+class AsyncConfigIntegrationTest {
 
   private static final String REQUEST_ID = "requestId";
   private static final String USER_ID = "userId";
@@ -32,7 +33,7 @@ class AsyncConfigTest {
   void givenCallerMdc_whenSubmittedToExecutor_thenPropagatedToWorkerAndCallerPreserved() {
     contextRunner.run(
         context -> {
-          // given — 실제 등록된 emailTaskExecutor 빈을 꺼내고 제출 스레드에 MDC를 세팅
+          // given: 실제 등록된 emailTaskExecutor 빈을 꺼내고 제출 스레드에 MDC를 세팅
           ThreadPoolTaskExecutor executor =
               context.getBean("emailTaskExecutor", ThreadPoolTaskExecutor.class);
           MDC.put(REQUEST_ID, "req-async");
@@ -42,7 +43,7 @@ class AsyncConfigTest {
           AtomicReference<String> userIdInWorker = new AtomicReference<>();
           AtomicReference<String> workerThreadName = new AtomicReference<>();
 
-          // when — executor로 작업을 제출하고 완료를 기다린다
+          // when: executor로 작업을 제출하고 완료를 기다린다
           Future<?> future =
               executor.submit(
                   () -> {
@@ -52,12 +53,12 @@ class AsyncConfigTest {
                   });
           future.get(2, TimeUnit.SECONDS);
 
-          // then — 별도 worker thread에서 실행되었고 부모 MDC가 전파됨
+          // then: 별도 worker thread에서 실행되었고 부모 MDC가 전파됨
           assertThat(workerThreadName.get()).startsWith("email-");
           assertThat(requestIdInWorker.get()).isEqualTo("req-async");
           assertThat(userIdInWorker.get()).isEqualTo("user-async");
 
-          // then — 제출 스레드의 MDC는 작업 제출/완료 후에도 그대로 유지됨
+          // then: 제출 스레드의 MDC는 작업 제출/완료 후에도 그대로 유지됨
           assertThat(MDC.get(REQUEST_ID)).isEqualTo("req-async");
           assertThat(MDC.get(USER_ID)).isEqualTo("user-async");
         });

--- a/src/test/java/com/beachcheck/global/logging/integration/AsyncConfigIntegrationTest.java
+++ b/src/test/java/com/beachcheck/global/logging/integration/AsyncConfigIntegrationTest.java
@@ -3,6 +3,7 @@ package com.beachcheck.global.logging.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.beachcheck.global.config.AsyncConfig;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -10,7 +11,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @DisplayName("AsyncConfig 통합 테스트 — emailTaskExecutor MDC 전파 설정 검증")
@@ -20,7 +24,8 @@ class AsyncConfigIntegrationTest {
   private static final String USER_ID = "userId";
 
   private final ApplicationContextRunner contextRunner =
-      new ApplicationContextRunner().withUserConfiguration(AsyncConfig.class);
+      new ApplicationContextRunner()
+          .withUserConfiguration(AsyncConfig.class, TestAsyncBeanConfig.class);
 
   @AfterEach
   void clearMdc() {
@@ -63,4 +68,45 @@ class AsyncConfigIntegrationTest {
           assertThat(MDC.get(USER_ID)).isEqualTo("user-async");
         });
   }
+
+  @Test
+  @DisplayName("@Async(\"emailTaskExecutor\") Bean 메서드 호출 시 부모 MDC가 worker thread로 전파된다")
+  void givenCallerMdc_whenAsyncBeanMethodCalled_thenMdcPropagatedThroughSpringAsyncProxy() {
+    contextRunner.run(
+        context -> {
+          AsyncProbe asyncProbe = context.getBean(AsyncProbe.class);
+          MDC.put(REQUEST_ID, "req-async-proxy");
+          MDC.put(USER_ID, "user-async-proxy");
+
+          ObservedMdc observed = asyncProbe.captureMdc().get(2, TimeUnit.SECONDS);
+
+          assertThat(observed.threadName()).startsWith("email-");
+          assertThat(observed.requestId()).isEqualTo("req-async-proxy");
+          assertThat(observed.userId()).isEqualTo("user-async-proxy");
+          assertThat(MDC.get(REQUEST_ID)).isEqualTo("req-async-proxy");
+          assertThat(MDC.get(USER_ID)).isEqualTo("user-async-proxy");
+        });
+  }
+
+  // 테스트용 @Async Bean과 관련 DTO (사이즈가 작아서 별도 파일로 분리하지 않음)
+
+  @TestConfiguration
+  static class TestAsyncBeanConfig {
+
+    @Bean
+    AsyncProbe asyncProbe() {
+      return new AsyncProbe();
+    }
+  }
+
+  static class AsyncProbe {
+
+    @Async("emailTaskExecutor")
+    public CompletableFuture<ObservedMdc> captureMdc() {
+      return CompletableFuture.completedFuture(
+          new ObservedMdc(MDC.get(REQUEST_ID), MDC.get(USER_ID), Thread.currentThread().getName()));
+    }
+  }
+
+  record ObservedMdc(String requestId, String userId, String threadName) {}
 }


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 이슈 링크 (필수)
- Jira: https://parkjaehong.atlassian.net/browse/PB-119
- GitHub: Related #229
- GitHub: Closes #229 (Final PR만)

> PR 제목: `[Feat] PB-119 @Async 경계 MDC(requestId/userId) 전파`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- Single PR (Stacked 아님). 선행 PB-116(MDC1, 머지 완료) 위에서 진행
- 선행 PR: #227 (PB-116 로깅 표준, 머지 완료)
- 후속 PR: 도메인 로그 키 / 스케줄러 MDC ADR 및 PR

### 이 PR에서 변경한 것
- `global/logging/MdcTaskDecorator.java` (신규): `TaskDecorator` 구현. 제출 시점 부모 MDC 복사 → worker thread 주입 → 실행 후 복원/정리
- `global/config/AsyncConfig.java` (수정): `emailTaskExecutor`에 `setTaskDecorator(new MdcTaskDecorator())` 적용 (`initialize()` 전 호출)
- `test/.../logging/MdcTaskDecoratorTest.java` (신규): 전파/정리/예외/복원 단위 테스트
- `test/.../config/AsyncConfigTest.java` (신규): `ApplicationContextRunner`로 실 executor 경유 전파 + 제출 스레드 MDC 유지 검증

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 부모 스레드 MDC(`requestId`/`userId`)가 decorated runnable 내부에서 동일하게 보임
- AC2: runnable 실행 후 worker thread MDC 정리 (부모 MDC가 비면 clear)
- AC3: runnable 예외 시에도 finally에서 worker thread MDC 정리/복원
- AC4: worker thread 기존 MDC가 있으면 실행 후 그 값으로 복원
- AC5: `emailTaskExecutor`에 `MdcTaskDecorator` 적용 확인 (통합 테스트)
- AC6: 인증 요청 파생 비동기 작업은 `userId` 유지 / 비인증은 비어 있음 (전파 로직상 보장)

### Not covered (후속 작업)
- 도메인 식별자(`notificationId`/`outboxEventId` 등) 로그 정책 → 별도 ADR로 정책 결정 후 후속 PR
- 스케줄러 `jobId`/`schedulerName` 정책 → 별도 ADR로 정책 결정 후 후속 PR
- `traceId`/`spanId` 자동 주입 → ADR-0XX 트레이싱 도입 범위

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew spotlessApply test --tests "com.beachcheck.global.logging.MdcTaskDecoratorTest" --tests "com.beachcheck.global.config.AsyncConfigTest"
```
- ✅ 결과: BUILD SUCCESSFUL (단위 테스트 4종 + 통합 테스트 1종 통과)
- 비고: `AsyncConfigTest`는 `ApplicationContextRunner` 사용으로 Testcontainers/Docker 불필요

### CI
- (자동 첨부)

### Smoke 테스트
- 시나리오: 회원가입/이메일 재발송 요청 → 요청 스레드와 `email-*` worker thread 로그에 동일 `requestId` 노출, 다음 비동기 작업에 이전 `requestId/userId` 미누수 확인
- 결과: 수동 검증 예정 (운영/로컬 로그 확인 영역)

---

## 🧭 영향 범위 체크 (필수)
- [ ] API 변경 (요약: )
- [ ] DB 변경 (마이그레이션: )
- [x] 설정 변경 (항목: `emailTaskExecutor` 빈에 TaskDecorator 적용 — 외부 설정/환경변수 변경 없음)
- [ ] Breaking change (무엇: ) — 로그 컨텍스트 보강만, 동작/응답 불변

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인:
  - `MdcTaskDecorator#decorate` — `finally`의 `previousContext` 복원/clear 분기 (worker thread 재사용 누수 차단 지점)
  - `AsyncConfig#emailTaskExecutor` — `setTaskDecorator(...)`가 `initialize()` 이전에 호출되는지
- 트레이드오프/대안:
  - worker MDC를 단순 `clear`가 아니라 `previousContext`로 복원 — 같은 스레드에 프레임워크/테스트가 미리 넣어둔 값까지 안전하게 보존하기 위함
  - 새 로그 키는 만들지 않고 MDC1 표준 키(`requestId`/`userId`)만 전파 (도메인/스케줄러 키는 ADR 선행)
