### PR TITLE
PB-120 MDC3: 스케줄러 MDC + 도메인 구조화 로그

### DIFF
--- a/src/main/java/com/beachcheck/beach/scheduler/BeachConditionScheduler.java
+++ b/src/main/java/com/beachcheck/beach/scheduler/BeachConditionScheduler.java
@@ -9,8 +9,10 @@ import com.beachcheck.external.congestion.CongestionCurrentResponse;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -41,13 +43,25 @@ public class BeachConditionScheduler {
 
   @Scheduled(cron = "0 0/30 * * * *")
   public void refreshConditions() {
-    log.info("Scheduled condition refresh triggered");
+
+    // MDC.clear()는 모든 키를 삭제하기 때문에, 아래와 같은 방식으로 필요한 키만 제거하도록 구현
+    // schedulerName과 job은 직접 쓰지는 않지만, 리소스 생명주기를 try-with-resources에 맡기기 위해 선언한 변수
+    String jobId = UUID.randomUUID().toString();
+    try (MDC.MDCCloseable schedulerName =
+            MDC.putCloseable("schedulerName", "beachConditionRefresh");
+        MDC.MDCCloseable job = MDC.putCloseable("jobId", jobId)) {
+      refreshConditionsInScope();
+    }
+  }
+
+  private void refreshConditionsInScope() {
+    log.info("예약된 해변 조건 새로고침 시작");
 
     List<Beach> beaches = beachRepository.findAll();
     for (Beach beach : beaches) {
       String code = beach.getCode();
       if (code == null || code.isBlank()) {
-        log.warn("Skip beach with missing code. beachId={}", beach.getId());
+        log.warn("코드가 없는 해변을 건너뜁니다. beachId={}", beach.getId());
         continue;
       }
 

--- a/src/main/java/com/beachcheck/notification/service/NotificationService.java
+++ b/src/main/java/com/beachcheck/notification/service/NotificationService.java
@@ -1,5 +1,7 @@
 package com.beachcheck.notification.service;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.beachcheck.notification.domain.Notification;
 import com.beachcheck.notification.repository.NotificationRepository;
 import com.beachcheck.outbox.domain.OutboxEvent;
@@ -41,5 +43,12 @@ public class NotificationService {
     OutboxEvent event =
         OutboxEvent.createPending(notification.getId(), OutboxEventType.PUSH_NOTIFICATION, null);
     outboxEventRepository.save(event);
+
+    log.info(
+        "Notification 생성 및 Outbox 이벤트 등록 완료",
+        kv("notificationId", notification.getId()),
+        kv("outboxEventId", event.getId()),
+        kv("userId", userId),
+        kv("notificationType", type));
   }
 }

--- a/src/main/java/com/beachcheck/outbox/config/OutboxSchedulingConfig.java
+++ b/src/main/java/com/beachcheck/outbox/config/OutboxSchedulingConfig.java
@@ -1,6 +1,8 @@
 package com.beachcheck.outbox.config;
 
 import com.beachcheck.outbox.service.OutboxPublisher;
+import java.util.UUID;
+import org.slf4j.MDC;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
@@ -35,10 +37,19 @@ public class OutboxSchedulingConfig {
   /**
    * Why: PENDING/FAILED_RETRIABLE 상태의 OutboxEvent를 주기적으로 폴링하여 FCM 전송
    *
-   * <p>Policy: fixedDelay 방식으로 이전 실행 완료 후 delay만큼 대기 (동시 실행 방지)
+   * <p>Policy:
+   *
+   * <ul>
+   *   <li>fixedDelay 방식으로 이전 실행 완료 후 delay만큼 대기 (동시 실행 방지)
+   *   <li>스케줄러 실행 구간에 schedulerName/jobId MDC를 짧은 scope로 주입 (HTTP requestId/userId 미주입)
+   * </ul>
    */
   @Scheduled(fixedDelayString = "${app.outbox.polling.fixed-delay:1000}")
   public void scheduleOutboxPolling() {
-    outboxPublisher.processPendingOutboxEvents();
+    String jobId = UUID.randomUUID().toString();
+    try (MDC.MDCCloseable schedulerName = MDC.putCloseable("schedulerName", "outboxPolling");
+        MDC.MDCCloseable job = MDC.putCloseable("jobId", jobId)) {
+      outboxPublisher.processPendingOutboxEvents();
+    }
   }
 }

--- a/src/main/java/com/beachcheck/outbox/service/OutboxEventDispatcher.java
+++ b/src/main/java/com/beachcheck/outbox/service/OutboxEventDispatcher.java
@@ -1,5 +1,7 @@
 package com.beachcheck.outbox.service;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.beachcheck.notification.domain.Notification;
 import com.beachcheck.notification.domain.Notification.NotificationStatus;
 import com.beachcheck.notification.repository.NotificationRepository;
@@ -11,6 +13,8 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
 import java.time.Duration;
 import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
  * 스프린트에서 성능 병목 측정 후 비동기 도입 검토
  */
 public class OutboxEventDispatcher {
+
+  private static final Logger log = LoggerFactory.getLogger(OutboxEventDispatcher.class);
 
   private final OutboxEventRepository outboxEventRepository;
   private final NotificationRepository notificationRepository;
@@ -52,6 +58,11 @@ public class OutboxEventDispatcher {
     if (notification.getStatus() == NotificationStatus.SENT) {
       event.markAsSent();
       outboxEventRepository.save(event);
+      log.info(
+          "Outbox 이벤트 멱등 스킵 (이미 발송됨)",
+          kv("outboxEventId", event.getId()),
+          kv("notificationId", event.getNotificationId()),
+          kv("outboxEventType", event.getEventType()));
       return;
     }
 
@@ -68,6 +79,13 @@ public class OutboxEventDispatcher {
       // 5. OutboxEvent 상태 업데이트
       event.markAsSent();
       outboxEventRepository.save(event);
+
+      log.info(
+          "Outbox 이벤트 발송 성공",
+          kv("outboxEventId", event.getId()),
+          kv("notificationId", event.getNotificationId()),
+          kv("outboxEventType", event.getEventType()),
+          kv("retryCount", event.getRetryCount()));
     } catch (FirebaseMessagingException e) {
       // Exponential Backoff 재시도 로직
       if (isPermanentFcmError(e)) {
@@ -75,6 +93,11 @@ public class OutboxEventDispatcher {
         notification.markAsFailed("errorCode: " + e.getMessagingErrorCode());
         notificationRepository.save(notification);
         outboxEventRepository.save(event);
+        log.warn(
+            "Outbox 이벤트 발송 영구 실패",
+            kv("outboxEventId", event.getId()),
+            kv("notificationId", event.getNotificationId()),
+            kv("messagingErrorCode", e.getMessagingErrorCode()));
         return;
       }
       Duration backoff = Duration.ofSeconds(1L << event.getRetryCount()); // 1s, 2s, 4s
@@ -84,9 +107,21 @@ public class OutboxEventDispatcher {
         notification.markAsFailed("errorCode: " + e.getMessagingErrorCode());
         notificationRepository.save(notification);
         outboxEventRepository.save(event);
+        log.warn(
+            "Outbox 이벤트 발송 영구 실패 (최대 재시도 초과)",
+            kv("outboxEventId", event.getId()),
+            kv("notificationId", event.getNotificationId()),
+            kv("retryCount", event.getRetryCount()),
+            kv("messagingErrorCode", e.getMessagingErrorCode()));
       } else {
         event.markAsFailedRetriable(backoff);
         outboxEventRepository.save(event);
+        log.warn(
+            "Outbox 이벤트 발송 실패 (재시도 예정)",
+            kv("outboxEventId", event.getId()),
+            kv("notificationId", event.getNotificationId()),
+            kv("retryCount", event.getRetryCount()),
+            kv("messagingErrorCode", e.getMessagingErrorCode()));
       }
     }
   }

--- a/src/main/java/com/beachcheck/outbox/service/OutboxPublisher.java
+++ b/src/main/java/com/beachcheck/outbox/service/OutboxPublisher.java
@@ -44,6 +44,11 @@ public class OutboxPublisher {
     List<OutboxEvent> pendingEvents =
         outboxEventRepository.findPendingEvents(now, PageRequest.of(0, batchSize));
 
+    if (pendingEvents.isEmpty()) {
+      log.debug("Outbox 폴링 대상 이벤트 없음");
+      return;
+    }
+
     log.info("Outbox 폴링 대상 이벤트 조회 완료", kv("outboxEventCount", pendingEvents.size()));
 
     for (OutboxEvent event : pendingEvents) {

--- a/src/main/java/com/beachcheck/outbox/service/OutboxPublisher.java
+++ b/src/main/java/com/beachcheck/outbox/service/OutboxPublisher.java
@@ -1,9 +1,13 @@
 package com.beachcheck.outbox.service;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.beachcheck.outbox.domain.OutboxEvent;
 import com.beachcheck.outbox.repository.OutboxEventRepository;
 import java.time.Instant;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
  * 문자열 키 오타/경로 불일치를 컴파일 타임에 차단 - @Min 등으로 batchSize > 0 제약을 애플리케이션 시작 시점에 fail-fast 검증
  */
 public class OutboxPublisher {
+
+  private static final Logger log = LoggerFactory.getLogger(OutboxPublisher.class);
 
   private final OutboxEventRepository outboxEventRepository;
   private final OutboxEventDispatcher outboxEventDispatcher;
@@ -37,6 +43,8 @@ public class OutboxPublisher {
     Instant now = Instant.now();
     List<OutboxEvent> pendingEvents =
         outboxEventRepository.findPendingEvents(now, PageRequest.of(0, batchSize));
+
+    log.info("Outbox 폴링 대상 이벤트 조회 완료", kv("outboxEventCount", pendingEvents.size()));
 
     for (OutboxEvent event : pendingEvents) {
       outboxEventDispatcher.dispatch(event);

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,19 +3,19 @@
   로깅 표준
   - dev/local/test/default: 사람이 읽기 좋은 평문
   - prod: NDJSON (logstash-logback-encoder)
-  - MDC 키 노출: traceId, spanId, userId, requestId
+  - MDC 키 노출: traceId, spanId, userId, requestId, schedulerName, jobId
 -->
 <configuration>
 
     <!-- 공통: MDC 키 노출 목록 (참조용) -->
-    <property name="MDC_KEYS" value="traceId,spanId,userId,requestId"/>
+    <property name="MDC_KEYS" value="traceId,spanId,userId,requestId,schedulerName,jobId"/>
 
     <!-- ─────────── dev / local / test / default: 평문 ─────────── -->
     <springProfile name="dev | local | test | default">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
                 <pattern>
-                    %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [traceId=%X{traceId:-},requestId=%X{requestId:-},userId=%X{userId:-}] %logger{36} - %msg%n
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [traceId=%X{traceId:-},requestId=%X{requestId:-},userId=%X{userId:-},schedulerName=%X{schedulerName:-},jobId=%X{jobId:-}] %logger{36} - %msg%n
                 </pattern>
             </encoder>
         </appender>
@@ -39,6 +39,8 @@
                 <includeMdcKeyName>spanId</includeMdcKeyName>
                 <includeMdcKeyName>userId</includeMdcKeyName>
                 <includeMdcKeyName>requestId</includeMdcKeyName>
+                <includeMdcKeyName>schedulerName</includeMdcKeyName>
+                <includeMdcKeyName>jobId</includeMdcKeyName>
                 <fieldNames>
                     <timestamp>@timestamp</timestamp>
                     <thread>thread</thread>

--- a/src/test/java/com/beachcheck/beach/scheduler/BeachConditionSchedulerTest.java
+++ b/src/test/java/com/beachcheck/beach/scheduler/BeachConditionSchedulerTest.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.locationtech.jts.geom.Point;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("BeachConditionScheduler 분기 테스트")
@@ -37,6 +39,31 @@ class BeachConditionSchedulerTest {
   @Mock private BeachRepository beachRepository;
   @Mock private BeachConditionRepository beachConditionRepository;
   @Mock private CongestionClient congestionClient;
+
+  @AfterEach
+  void clearMdc() {
+    MDC.clear();
+  }
+
+  @Nested
+  @DisplayName("스케줄러 MDC scope")
+  class SchedulerMdcScope {
+
+    @Test
+    @DisplayName("TC-SCH-MDC-01: refreshConditions 종료 후 schedulerName/jobId MDC가 남지 않는다")
+    void tcSchMdc01_clearsSchedulerMdcAfterExecution() {
+      // Given
+      BeachConditionScheduler scheduler = schedulerWithMode("ai");
+      given(beachRepository.findAll()).willReturn(List.of());
+
+      // When
+      scheduler.refreshConditions();
+
+      // Then
+      assertThat(MDC.get("schedulerName")).isNull();
+      assertThat(MDC.get("jobId")).isNull();
+    }
+  }
 
   @Nested
   @DisplayName("refreshConditions 메서드")

--- a/src/test/java/com/beachcheck/global/logging/DtoLoggingCatalogTest.java
+++ b/src/test/java/com/beachcheck/global/logging/DtoLoggingCatalogTest.java
@@ -1,5 +1,6 @@
 package com.beachcheck.global.logging;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.beachcheck.auth.dto.request.LogInRequestDto;
@@ -82,6 +83,8 @@ class DtoLoggingCatalogTest {
         .contains("traceId=trace-catalog")
         .contains("requestId=request-catalog")
         .contains("userId=user-catalog")
+        .contains("schedulerName=scheduler-catalog")
+        .contains("jobId=job-catalog")
         .contains("LogInRequestDto[****]")
         .contains("BeachSearchRequestDto")
         .doesNotContain(SAMPLE_EMAIL)
@@ -108,6 +111,9 @@ class DtoLoggingCatalogTest {
         .contains("\"spanId\":\"span-catalog\"")
         .contains("\"userId\":\"user-catalog\"")
         .contains("\"requestId\":\"request-catalog\"")
+        .contains("\"schedulerName\":\"scheduler-catalog\"")
+        .contains("\"jobId\":\"job-catalog\"")
+        .contains("\"notificationId\":\"" + SAMPLE_ID + "\"")
         .contains("LogInRequestDto[****]")
         .contains("BeachSearchRequestDto")
         .doesNotContain(SAMPLE_EMAIL)
@@ -132,6 +138,8 @@ class DtoLoggingCatalogTest {
     for (Map.Entry<String, Object> dto : sampleDtos()) {
       log.info("dtoName={}, dto={}", dto.getKey(), dto.getValue());
     }
+    log.info(
+        "구조화 로그 카탈로그 샘플", kv("notificationId", SAMPLE_ID), kv("outboxEventId", SAMPLE_BEACH_ID));
   }
 
   private void putCatalogMdc() {
@@ -139,6 +147,8 @@ class DtoLoggingCatalogTest {
     MDC.put("spanId", "span-catalog");
     MDC.put("userId", "user-catalog");
     MDC.put("requestId", "request-catalog");
+    MDC.put("schedulerName", "scheduler-catalog");
+    MDC.put("jobId", "job-catalog");
   }
 
   private List<Map.Entry<String, Object>> sampleDtos() {

--- a/src/test/java/com/beachcheck/outbox/config/OutboxSchedulingConfigTest.java
+++ b/src/test/java/com/beachcheck/outbox/config/OutboxSchedulingConfigTest.java
@@ -1,0 +1,60 @@
+package com.beachcheck.outbox.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+import com.beachcheck.outbox.service.OutboxPublisher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+
+/**
+ * Why: 스케줄러 진입점이 OutboxPublisher에 위임하고, schedulerName/jobId MDC scope가 실행 후 누수되지 않는지 검증.
+ *
+ * <p>Policy: BDDMockito 스타일, Given-When-Then 구조
+ *
+ * <p>Contract(Input): Mock OutboxPublisher
+ *
+ * <p>Contract(Output): processPendingOutboxEvents() 호출 여부, 실행 후 MDC 정리 상태
+ */
+@ExtendWith(MockitoExtension.class)
+class OutboxSchedulingConfigTest {
+
+  @Mock private OutboxPublisher outboxPublisher;
+
+  @AfterEach
+  void clearMdc() {
+    MDC.clear();
+  }
+
+  @Test
+  @DisplayName("TC1 - scheduleOutboxPolling은 OutboxPublisher에 위임한다")
+  void shouldDelegateToOutboxPublisher() {
+    // Given
+    OutboxSchedulingConfig config = new OutboxSchedulingConfig(outboxPublisher);
+
+    // When
+    config.scheduleOutboxPolling();
+
+    // Then
+    then(outboxPublisher).should().processPendingOutboxEvents();
+  }
+
+  @Test
+  @DisplayName("TC2 - 실행 종료 후 schedulerName/jobId MDC가 남지 않는다")
+  void shouldClearSchedulerMdcAfterExecution() {
+    // Given
+    OutboxSchedulingConfig config = new OutboxSchedulingConfig(outboxPublisher);
+
+    // When
+    config.scheduleOutboxPolling();
+
+    // Then
+    assertThat(MDC.get("schedulerName")).isNull();
+    assertThat(MDC.get("jobId")).isNull();
+  }
+}


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 이슈 링크
- Jira: PB-120
- GitHub: Closes #231

---

## 🧩 이 PR의 변경사항
### 이 PR에서 변경한 것
- 스케줄러 실행 구간에 `schedulerName`, `jobId` 짧은 MDC scope 적용 (`OutboxSchedulingConfig`, `BeachConditionScheduler`)
- 도메인 식별자(`notificationId`, `outboxEventId` 등)를 `StructuredArguments.kv`로 기록 (`NotificationService`, `OutboxPublisher`, `OutboxEventDispatcher`)
- `logback-spring.xml` dev/prod 로그에 `schedulerName`, `jobId` 노출
- 로그 포맷/스케줄러 MDC 누수 방지 테스트 보강 (`DtoLoggingCatalogTest`, `BeachConditionSchedulerTest`, 신규 `OutboxSchedulingConfigTest`)

> 선행: MDC1(HTTP requestId/userId), MDC2(@Async 전파, PB-119 #229)
> 근거: ADR-010 로깅 표준 §3 MDC 표준 키, §4 도메인 로그 필드 정책, §5 스케줄러 MDC 정책

---

## ✅ AC (이 PR 범위만)
- [x] `logback-spring.xml` dev/prod 로그에 `schedulerName`, `jobId` 노출
- [x] Outbox/BeachCondition 스케줄러 실행 중 `schedulerName`/`jobId` MDC 주입, 종료 후 누수 없음 (테스트 검증)
- [x] `NotificationService`/`OutboxEventDispatcher` 로그에 도메인 식별자가 structured field로 기록
- [x] 스케줄러에 `requestId`/`userId` 미주입, `traceId`/`spanId` 직접 생성 안 함
- [x] `MdcScope` helper 미포함 (반복 패턴 2곳 이상 확인 시 후속 PR)

---

## 🧪 테스트 결과
### 로컬
```
./gradlew test --tests "com.beachcheck.global.logging.DtoLoggingCatalogTest" \
  --tests "com.beachcheck.beach.scheduler.BeachConditionSchedulerTest" \
  --tests "com.beachcheck.outbox.config.OutboxSchedulingConfigTest" \
  --tests "com.beachcheck.outbox.service.OutboxPublisherTest" \
  --tests "com.beachcheck.outbox.service.OutboxEventDispatcherTest"
```
- ✅ 결과: BUILD SUCCESSFUL (단위 테스트 통과). spotlessApply 적용 완료.
- ℹ️ Testcontainers 통합 테스트(`outbox.integration.*`)는 Docker 필요로 본 변경 범위에서 미실행.

---

## 🧭 영향 범위 체크
- [ ] API 변경
- [ ] DB 변경
- [ ] 설정 변경
- [ ] Breaking change
- (로그 필드 추가만 — API/DB/외부 연동 런타임 계약 변경 없음)

---

## 💬 리뷰 포인트
- 집중해서 볼 파일/라인:
  - `OutboxEventDispatcher`: 성공/멱등스킵/영구실패/재시도 경로별 structured 로그 (중복 로깅 없는지)
  - 스케줄러 `try (MDC.MDCCloseable ...)` scope 종료 시 MDC 정리
- 트레이드오프/대안: 도메인 식별자를 MDC가 아닌 structured argument로 둔 이유는 스레드 재사용 누수/필드 의미 혼동 방지 (ADR-010 §4 근거).
